### PR TITLE
Add settings screen

### DIFF
--- a/.idea/.idea.Circle/.idea/vcs.xml
+++ b/.idea/.idea.Circle/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/Circle.Game.Tests/Visual/UserInterface/TestSceneRollingControl.cs
+++ b/Circle.Game.Tests/Visual/UserInterface/TestSceneRollingControl.cs
@@ -1,0 +1,69 @@
+﻿using Circle.Game.Graphics.UserInterface;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Shapes;
+using osuTK.Graphics;
+
+namespace Circle.Game.Tests.Visual.UserInterface
+{
+    public class TestSceneRollingControl : CircleTestScene
+    {
+        private RollingControl<string> control;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Add(new Box { RelativeSizeAxes = Axes.Both, Colour = Color4.DarkGray });
+            Add(new RollingControl<int>
+            {
+                Anchor = Anchor.TopCentre,
+                Origin = Anchor.TopCentre,
+                Text = "Rolling Control",
+                Item = new RollingItem<int>[]
+                {
+                    new RollingItem<int>(1),
+                    new RollingItem<int>(2),
+                    new RollingItem<int>(3),
+                }
+            });
+            Add(control = new RollingControl<string>
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Text = "Rolling Control",
+                Item = new RollingItem<string>[]
+                {
+                    new RollingItem<string>("value1"),
+                    new RollingItem<string>("value2"),
+                    new RollingItem<string>("value3"),
+                }
+            });
+            Add(new RollingControl<testEnum>
+            {
+                Anchor = Anchor.BottomCentre,
+                Origin = Anchor.BottomCentre,
+                Text = "Rolling Control",
+                Item = new RollingItem<testEnum>[]
+                {
+                    new RollingItem<testEnum>(testEnum.Enum1),
+                    new RollingItem<testEnum>(testEnum.Enum2),
+                    new RollingItem<testEnum>(testEnum.Enum3),
+                }
+            });
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            control.SetCurrent("value1");
+        }
+
+        private enum testEnum
+        {
+            Enum1,
+            Enum2,
+            Enum3
+        }
+    }
+}

--- a/Circle.Game.Tests/Visual/UserInterface/TestSceneRollingControl.cs
+++ b/Circle.Game.Tests/Visual/UserInterface/TestSceneRollingControl.cs
@@ -19,7 +19,7 @@ namespace Circle.Game.Tests.Visual.UserInterface
                 Anchor = Anchor.TopCentre,
                 Origin = Anchor.TopCentre,
                 Text = "Rolling Control",
-                Item = new RollingItem<int>[]
+                Item = new[]
                 {
                     new RollingItem<int>(1),
                     new RollingItem<int>(2),
@@ -31,23 +31,23 @@ namespace Circle.Game.Tests.Visual.UserInterface
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 Text = "Rolling Control",
-                Item = new RollingItem<string>[]
+                Item = new[]
                 {
                     new RollingItem<string>("value1"),
                     new RollingItem<string>("value2"),
                     new RollingItem<string>("value3"),
                 }
             });
-            Add(new RollingControl<testEnum>
+            Add(new RollingControl<TestEnum>
             {
                 Anchor = Anchor.BottomCentre,
                 Origin = Anchor.BottomCentre,
                 Text = "Rolling Control",
-                Item = new RollingItem<testEnum>[]
+                Item = new[]
                 {
-                    new RollingItem<testEnum>(testEnum.Enum1),
-                    new RollingItem<testEnum>(testEnum.Enum2),
-                    new RollingItem<testEnum>(testEnum.Enum3),
+                    new RollingItem<TestEnum>(TestEnum.Enum1),
+                    new RollingItem<TestEnum>(TestEnum.Enum2),
+                    new RollingItem<TestEnum>(TestEnum.Enum3),
                 }
             });
         }
@@ -59,7 +59,7 @@ namespace Circle.Game.Tests.Visual.UserInterface
             control.SetCurrent("value1");
         }
 
-        private enum testEnum
+        private enum TestEnum
         {
             Enum1,
             Enum2,

--- a/Circle.Game/Graphics/UserInterface/CircleScrollContainer.cs
+++ b/Circle.Game/Graphics/UserInterface/CircleScrollContainer.cs
@@ -1,0 +1,180 @@
+﻿using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Events;
+using osuTK;
+using osuTK.Graphics;
+using osuTK.Input;
+
+namespace Circle.Game.Graphics.UserInterface
+{
+    public class CircleScrollContainer : CircleScrollContainer<Drawable>
+    {
+        public CircleScrollContainer()
+        {
+        }
+
+        public CircleScrollContainer(Direction direction)
+            : base(direction)
+        {
+        }
+    }
+
+    public class CircleScrollContainer<T> : ScrollContainer<T> where T : Drawable
+    {
+        public const float SCROLL_BAR_HEIGHT = 10;
+        public const float SCROLL_BAR_PADDING = 3;
+
+        /// <summary>
+        /// Allows controlling the scroll bar from any position in the container using the right mouse button.
+        /// Uses the value of <see cref="DistanceDecayOnRightMouseScrollbar"/> to smoothly scroll to the dragged location.
+        /// </summary>
+        public bool RightMouseScrollbar;
+
+        /// <summary>
+        /// Controls the rate with which the target position is approached when performing a relative drag. Default is 0.02.
+        /// </summary>
+        public double DistanceDecayOnRightMouseScrollbar = 0.02;
+
+        private bool shouldPerformRightMouseScroll(MouseButtonEvent e) => RightMouseScrollbar && e.Button == MouseButton.Right;
+
+        private void scrollFromMouseEvent(MouseEvent e) =>
+            ScrollTo(Clamp(ToLocalSpace(e.ScreenSpaceMousePosition)[ScrollDim] / DrawSize[ScrollDim]) * Content.DrawSize[ScrollDim], true, DistanceDecayOnRightMouseScrollbar);
+
+        private bool rightMouseDragging;
+
+        protected override bool IsDragging => base.IsDragging || rightMouseDragging;
+
+        public CircleScrollContainer(Direction scrollDirection = Direction.Vertical)
+            : base(scrollDirection)
+        {
+        }
+
+        protected override bool OnMouseDown(MouseDownEvent e)
+        {
+            if (shouldPerformRightMouseScroll(e))
+            {
+                scrollFromMouseEvent(e);
+                return true;
+            }
+
+            return base.OnMouseDown(e);
+        }
+
+        protected override void OnDrag(DragEvent e)
+        {
+            if (rightMouseDragging)
+            {
+                scrollFromMouseEvent(e);
+                return;
+            }
+
+            base.OnDrag(e);
+        }
+
+        protected override bool OnDragStart(DragStartEvent e)
+        {
+            if (shouldPerformRightMouseScroll(e))
+            {
+                rightMouseDragging = true;
+                return true;
+            }
+
+            return base.OnDragStart(e);
+        }
+
+        protected override void OnDragEnd(DragEndEvent e)
+        {
+            if (rightMouseDragging)
+            {
+                rightMouseDragging = false;
+                return;
+            }
+
+            base.OnDragEnd(e);
+        }
+
+        protected override ScrollbarContainer CreateScrollbar(Direction direction) => new CircleScrollbar(direction);
+
+        protected class CircleScrollbar : ScrollbarContainer
+        {
+            private Color4 hoverColour;
+            private Color4 defaultColour;
+            private Color4 highlightColour;
+
+            private readonly Box box;
+
+            public CircleScrollbar(Direction scrollDir)
+                : base(scrollDir)
+            {
+                Blending = BlendingParameters.Additive;
+
+                CornerRadius = 5;
+
+                // needs to be set initially for the ResizeTo to respect minimum size
+                Size = new Vector2(SCROLL_BAR_HEIGHT);
+
+                const float margin = 3;
+
+                Margin = new MarginPadding
+                {
+                    Left = scrollDir == Direction.Vertical ? margin : 0,
+                    Right = scrollDir == Direction.Vertical ? margin : 0,
+                    Top = scrollDir == Direction.Horizontal ? margin : 0,
+                    Bottom = scrollDir == Direction.Horizontal ? margin : 0,
+                };
+
+                Masking = true;
+                Child = box = new Box { RelativeSizeAxes = Axes.Both };
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                Colour = defaultColour = Color4.Black.Opacity(0.4f);
+                hoverColour = Color4.White.Opacity(0.4f);
+                highlightColour = Color4.Gray;
+            }
+
+            public override void ResizeTo(float val, int duration = 0, Easing easing = Easing.None)
+            {
+                Vector2 size = new Vector2(SCROLL_BAR_HEIGHT)
+                {
+                    [(int)ScrollDirection] = val
+                };
+                this.ResizeTo(size, duration, easing);
+            }
+
+            protected override bool OnHover(HoverEvent e)
+            {
+                this.FadeColour(hoverColour, 100);
+                return true;
+            }
+
+            protected override void OnHoverLost(HoverLostEvent e)
+            {
+                this.FadeColour(defaultColour, 200);
+            }
+
+            protected override bool OnMouseDown(MouseDownEvent e)
+            {
+                if (!base.OnMouseDown(e)) return false;
+
+                // note that we are changing the colour of the box here as to not interfere with the hover effect.
+                box.FadeColour(highlightColour, 100);
+                return true;
+            }
+
+            protected override void OnMouseUp(MouseUpEvent e)
+            {
+                if (e.Button != MouseButton.Left) return;
+
+                box.FadeColour(Color4.White, 200);
+
+                base.OnMouseUp(e);
+            }
+        }
+    }
+}

--- a/Circle.Game/Graphics/UserInterface/IconButton.cs
+++ b/Circle.Game/Graphics/UserInterface/IconButton.cs
@@ -1,0 +1,38 @@
+﻿using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osuTK;
+
+namespace Circle.Game.Graphics.UserInterface
+{
+    public class IconButton : CircleButton
+    {
+        public const float DEFAULT_BUTTON_SIZE = 30;
+
+        public IconUsage Icon
+        {
+            get => icon.Icon;
+            set => icon.Icon = value;
+        }
+
+        public Vector2 IconScale
+        {
+            get => icon.Scale;
+            set => icon.Scale = value;
+        }
+
+        private readonly SpriteIcon icon;
+
+        public IconButton(bool useBackground = true)
+            : base(useBackground)
+        {
+            Size = new Vector2(DEFAULT_BUTTON_SIZE);
+            Content.Add(icon = new SpriteIcon
+            {
+                Origin = Anchor.Centre,
+                Anchor = Anchor.Centre,
+                RelativeSizeAxes = Axes.Both,
+                Size = new Vector2(0.6f)
+            });
+        }
+    }
+}

--- a/Circle.Game/Graphics/UserInterface/RollingControl.cs
+++ b/Circle.Game/Graphics/UserInterface/RollingControl.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Circle.Game.Configuration;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;

--- a/Circle.Game/Graphics/UserInterface/RollingControl.cs
+++ b/Circle.Game/Graphics/UserInterface/RollingControl.cs
@@ -1,0 +1,185 @@
+﻿using System;
+using Circle.Game.Configuration;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osuTK;
+using osuTK.Graphics;
+
+namespace Circle.Game.Graphics.UserInterface
+{
+    /// <summary>
+    /// 방향으로 값을 바꿀 수있는 컨트롤.
+    /// </summary>
+    /// <typeparam name="T">바꿀 값.</typeparam>
+    public class RollingControl<T> : Container
+    {
+        /// <summary>
+        /// 이 설정이 무엇인지 표시합니다.
+        /// </summary>
+        public string Text { get; set; }
+
+        /// <summary>
+        /// 아이템들.
+        /// </summary>
+        public RollingItem<T>[] Item;
+
+        /// <summary>
+        /// 현재 값.
+        /// </summary>
+        public Bindable<T> Current { get; set; } = new Bindable<T>();
+
+        /// <summary>
+        /// 아이템에 설정되어있는 값을 표시합니다.
+        /// </summary>
+        private SpriteText text;
+
+        /// <summary>
+        /// 현재 아이템의 인덱스. 기본 값은 -1입니다.
+        /// </summary>
+        private int currentIdx = -1;
+
+        /// <summary>
+        /// 방향으로 값을 바꿀 수있는 컨트롤.
+        /// </summary>
+        public RollingControl()
+        {
+            CornerRadius = 5;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Masking = true;
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            Children = new Drawable[]
+            {
+                new Box
+                {
+                    Colour = Color4.Black,
+                    RelativeSizeAxes = Axes.Both,
+                    Alpha = 0.2f
+                },
+                new SpriteText
+                {
+                    Text = Text,
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    Margin = new MarginPadding { Left = 20 },
+                    Font = FontUsage.Default.With(size: 22)
+                },
+                new Container
+                {
+                    Margin = new MarginPadding { Right = 20 },
+                    Anchor = Anchor.CentreRight,
+                    Origin = Anchor.CentreRight,
+                    RelativeSizeAxes = Axes.X,
+                    Height = 50,
+                    Width = 0.4f,
+                    Children = new Drawable[]
+                    {
+                        new IconButton
+                        {
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
+                            Icon = FontAwesome.Solid.AngleLeft,
+                            Action = () => changeCurrent(direction.Backward),
+                            Size = new Vector2(32)
+                        },
+                        new IconButton
+                        {
+                            Anchor = Anchor.CentreRight,
+                            Origin = Anchor.CentreRight,
+                            Icon = FontAwesome.Solid.AngleRight,
+                            Action = () => changeCurrent(direction.Forward),
+                            Size = new Vector2(32)
+                        },
+                        text = new SpriteText
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Font = FontUsage.Default.With(size: 22)
+                        }
+                    }
+                }
+            };
+        }
+
+        private void setAction()
+        {
+            foreach (var item in Item)
+            {
+            }
+        }
+
+        /// <summary>
+        /// 값을 설정하고 동작을 실행합니다.
+        /// </summary>
+        /// <param name="toValue">바꿀 값.</param>
+        public void SetCurrent(T toValue)
+        {
+            var isExist = false;
+
+            // 값의 존재여부, currentIndex를 바꿉니다.
+            foreach (var i in Item)
+            {
+                if (i.Value.Equals(toValue))
+                {
+                    isExist = true;
+                    currentIdx = Array.FindIndex(Item, i => i.Value.Equals(toValue));
+                    break;
+                }
+            }
+
+            // 값이 존재하지않는다면 아래 코드를 실행하지 않습니다.
+            if (!isExist)
+                return;
+
+            // 새로운 값으로 바꿉니다.
+            Current.Value = toValue;
+            text.Text = Item[currentIdx].Text;
+
+            // 동작을 실행합니다.
+            if (Item[currentIdx].Action != null)
+                Item[currentIdx].Action.Invoke();
+        }
+
+        /// <summary>
+        /// 방향으로 Item 인덱스를 바꾸고 SetCurrent()를 실행합니다.
+        /// </summary>
+        /// <param name="direction">방향.</param>
+        private void changeCurrent(direction direction)
+        {
+            // 아이템들이 없거나 할당이 되어있지 않다면 아래 코드를 실행하지 않습니다.
+            if (Item is null)
+                return;
+            else if (Item.Length == 0)
+                return;
+
+            if (direction == direction.Forward)
+            {
+                if (currentIdx + 1 >= Item.Length)
+                    SetCurrent(Item[0].Value);
+                else
+                    SetCurrent(Item[currentIdx + 1].Value);
+            }
+            else
+            {
+                if (currentIdx <= 0)
+                    SetCurrent(Item[Item.Length - 1].Value);
+                else
+                    SetCurrent(Item[currentIdx - 1].Value);
+            }
+        }
+
+        private enum direction
+        {
+            Forward,
+            Backward
+        }
+    }
+}

--- a/Circle.Game/Graphics/UserInterface/RollingControl.cs
+++ b/Circle.Game/Graphics/UserInterface/RollingControl.cs
@@ -86,7 +86,7 @@ namespace Circle.Game.Graphics.UserInterface
                             Anchor = Anchor.CentreLeft,
                             Origin = Anchor.CentreLeft,
                             Icon = FontAwesome.Solid.AngleLeft,
-                            Action = () => changeCurrent(direction.Backward),
+                            Action = () => changeCurrent(Direction.Backward),
                             Size = new Vector2(32)
                         },
                         new IconButton
@@ -94,7 +94,7 @@ namespace Circle.Game.Graphics.UserInterface
                             Anchor = Anchor.CentreRight,
                             Origin = Anchor.CentreRight,
                             Icon = FontAwesome.Solid.AngleRight,
-                            Action = () => changeCurrent(direction.Forward),
+                            Action = () => changeCurrent(Direction.Forward),
                             Size = new Vector2(32)
                         },
                         text = new SpriteText
@@ -122,7 +122,7 @@ namespace Circle.Game.Graphics.UserInterface
                 if (i.Value.Equals(toValue))
                 {
                     isExist = true;
-                    currentIdx = Array.FindIndex(Item, i => i.Value.Equals(toValue));
+                    currentIdx = Array.FindIndex(Item, r => r.Value.Equals(toValue));
                     break;
                 }
             }
@@ -144,7 +144,7 @@ namespace Circle.Game.Graphics.UserInterface
         /// 방향으로 Item 인덱스를 바꾸고 SetCurrent()를 실행합니다.
         /// </summary>
         /// <param name="direction">방향.</param>
-        private void changeCurrent(direction direction)
+        private void changeCurrent(Direction direction)
         {
             // 아이템들이 없거나 할당이 되어있지 않다면 아래 코드를 실행하지 않습니다.
             if (Item is null)
@@ -152,23 +152,13 @@ namespace Circle.Game.Graphics.UserInterface
             else if (Item.Length == 0)
                 return;
 
-            if (direction == direction.Forward)
-            {
-                if (currentIdx + 1 >= Item.Length)
-                    SetCurrent(Item[0].Value);
-                else
-                    SetCurrent(Item[currentIdx + 1].Value);
-            }
+            if (direction == Direction.Forward)
+                SetCurrent(currentIdx + 1 >= Item.Length ? Item[0].Value : Item[currentIdx + 1].Value);
             else
-            {
-                if (currentIdx <= 0)
-                    SetCurrent(Item[Item.Length - 1].Value);
-                else
-                    SetCurrent(Item[currentIdx - 1].Value);
-            }
+                SetCurrent(currentIdx <= 0 ? Item[Item.Length - 1].Value : Item[currentIdx - 1].Value);
         }
 
-        private enum direction
+        private enum Direction
         {
             Forward,
             Backward

--- a/Circle.Game/Graphics/UserInterface/RollingControl.cs
+++ b/Circle.Game/Graphics/UserInterface/RollingControl.cs
@@ -109,13 +109,6 @@ namespace Circle.Game.Graphics.UserInterface
             };
         }
 
-        private void setAction()
-        {
-            foreach (var item in Item)
-            {
-            }
-        }
-
         /// <summary>
         /// 값을 설정하고 동작을 실행합니다.
         /// </summary>

--- a/Circle.Game/Graphics/UserInterface/RollingControl.cs
+++ b/Circle.Game/Graphics/UserInterface/RollingControl.cs
@@ -155,7 +155,7 @@ namespace Circle.Game.Graphics.UserInterface
             if (direction == Direction.Forward)
                 SetCurrent(currentIdx + 1 >= Item.Length ? Item[0].Value : Item[currentIdx + 1].Value);
             else
-                SetCurrent(currentIdx <= 0 ? Item[Item.Length - 1].Value : Item[currentIdx - 1].Value);
+                SetCurrent(currentIdx <= 0 ? Item[^1].Value : Item[currentIdx - 1].Value);
         }
 
         private enum Direction

--- a/Circle.Game/Graphics/UserInterface/RollingItem.cs
+++ b/Circle.Game/Graphics/UserInterface/RollingItem.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using Circle.Game.Configuration;
+using osu.Framework.Allocation;
+using osu.Framework.Configuration;
 
 namespace Circle.Game.Graphics.UserInterface
 {
@@ -16,28 +19,30 @@ namespace Circle.Game.Graphics.UserInterface
         /// <summary>
         /// 해당 아이템이 선택되었을 때 실행됩니다.
         /// </summary>
-        public Action Action { get; set; }
+        public Action Action { get; }
 
         /// <summary>
         /// 임의로 값을 표시할 수 있습니다.
         /// </summary>
         public string Text;
 
+        [Resolved]
+        private CircleConfigManager localConfig { get; set; }
+
+        [Resolved]
+        private FrameworkConfigManager config { get; set; }
+
         /// <summary>
         /// 값과 액션을 포함하는 아이템.
         /// </summary>
         /// <param name="value">값.</param>
         /// <param name="action"></param>
+        [Obsolete]
         public RollingItem(T value, Action action = null)
         {
             Value = value;
             Action = action;
             Text = Value.ToString();
-
-            if (GetType() != typeof(string))
-            {
-                Text = Value.ToString();
-            }
         }
 
         /// <summary>
@@ -46,11 +51,26 @@ namespace Circle.Game.Graphics.UserInterface
         /// <param name="value">값.</param>
         /// <param name="text">임의로 표시할 내용</param>
         /// <param name="action"></param>
+        [Obsolete]
         public RollingItem(T value, string text, Action action = null)
         {
             Value = value;
             Text = text;
             Action = action;
+        }
+
+        public RollingItem(T value, CircleSetting lookup, string text = null)
+        {
+            Value = value;
+            Action = () => localConfig.SetValue(lookup, value);
+            Text = text != null ? text : value.ToString();
+        }
+
+        public RollingItem(T value, FrameworkSetting lookup, string text = null)
+        {
+            Value = value;
+            Action = () => config.SetValue(lookup, value);
+            Text = text != null ? text : value.ToString();
         }
     }
 }

--- a/Circle.Game/Graphics/UserInterface/RollingItem.cs
+++ b/Circle.Game/Graphics/UserInterface/RollingItem.cs
@@ -1,0 +1,56 @@
+﻿using System;
+
+namespace Circle.Game.Graphics.UserInterface
+{
+    /// <summary>
+    ///
+    /// </summary>
+    /// <typeparam name="T">CS0453</typeparam>
+    public class RollingItem<T>
+    {
+        /// <summary>
+        /// 값을 올바르게 할당해야합니다. 값이 같은 아이템이 있으면 올바른 작동을 하지 않을 수 있습니다.
+        /// </summary>
+        public T Value { get; set; }
+
+        /// <summary>
+        /// 해당 아이템이 선택되었을 때 실행됩니다.
+        /// </summary>
+        public Action Action { get; set; }
+
+        /// <summary>
+        /// 임의로 값을 표시할 수 있습니다.
+        /// </summary>
+        public string Text;
+
+        /// <summary>
+        /// 값과 액션을 포함하는 아이템.
+        /// </summary>
+        /// <param name="value">값.</param>
+        /// <param name="action"></param>
+        public RollingItem(T value, Action action = null)
+        {
+            Value = value;
+            Action = action;
+            Text = Value.ToString();
+
+            if (GetType() != typeof(string))
+            {
+                Text = Value.ToString();
+            }
+        }
+
+        /// <summary>
+        /// 값과 액션을 포함하는 아이템.
+        /// </summary>
+        /// <param name="value">값.</param>
+        /// <param name="text">임의로 표시할 내용</param>
+        /// <param name="action"></param>
+        public RollingItem(T value, string text, Action action = null)
+        {
+            Value = value;
+            Text = text;
+            Action = action;
+        }
+    }
+}

--- a/Circle.Game/Graphics/UserInterface/RollingItem.cs
+++ b/Circle.Game/Graphics/UserInterface/RollingItem.cs
@@ -61,14 +61,14 @@ namespace Circle.Game.Graphics.UserInterface
         {
             Value = value;
             Action = () => localConfig.SetValue(lookup, value);
-            Text = text != null ? text : value.ToString();
+            Text = text ?? value.ToString();
         }
 
         public RollingItem(T value, FrameworkSetting lookup, string text = null)
         {
             Value = value;
             Action = () => config.SetValue(lookup, value);
-            Text = text != null ? text : value.ToString();
+            Text = text ?? value.ToString();
         }
     }
 }

--- a/Circle.Game/Graphics/UserInterface/RollingItem.cs
+++ b/Circle.Game/Graphics/UserInterface/RollingItem.cs
@@ -37,7 +37,6 @@ namespace Circle.Game.Graphics.UserInterface
         /// </summary>
         /// <param name="value">값.</param>
         /// <param name="action"></param>
-        [Obsolete]
         public RollingItem(T value, Action action = null)
         {
             Value = value;
@@ -51,7 +50,6 @@ namespace Circle.Game.Graphics.UserInterface
         /// <param name="value">값.</param>
         /// <param name="text">임의로 표시할 내용</param>
         /// <param name="action"></param>
-        [Obsolete]
         public RollingItem(T value, string text, Action action = null)
         {
             Value = value;

--- a/Circle.Game/Screens/CircleScreen.cs
+++ b/Circle.Game/Screens/CircleScreen.cs
@@ -58,6 +58,6 @@ namespace Circle.Game.Screens
             return base.OnKeyDown(e);
         }
 
-        protected virtual void OnExit() => this.Exit();
+        public virtual void OnExit() => this.Exit();
     }
 }

--- a/Circle.Game/Screens/CircleScreen.cs
+++ b/Circle.Game/Screens/CircleScreen.cs
@@ -1,10 +1,16 @@
 ﻿using osu.Framework.Graphics;
+using osu.Framework.Input.Events;
 using osu.Framework.Screens;
+using osuTK.Input;
 
 namespace Circle.Game.Screens
 {
-    public class CircleScreen : Screen
+    public class CircleScreen : Screen, ICircleScreen
     {
+        public virtual bool BlockExit => false;
+
+        public virtual string Header => string.Empty;
+
         public CircleScreen()
         {
             Anchor = Anchor.Centre;
@@ -25,5 +31,33 @@ namespace Circle.Game.Screens
 
             return base.OnExiting(next);
         }
+
+        public override void OnResuming(IScreen last)
+        {
+            base.OnResuming(last);
+
+            X = DrawWidth;
+            this.MoveToX(0, 1000, Easing.OutPow10);
+        }
+
+        public override void OnSuspending(IScreen next)
+        {
+            base.OnSuspending(next);
+
+            this.MoveToX(DrawWidth, 1000, Easing.OutPow10);
+        }
+
+        protected override bool OnKeyDown(KeyDownEvent e)
+        {
+            if (e.Key == Key.Escape && !e.Repeat && !BlockExit)
+            {
+                OnExit();
+                return true;
+            }
+
+            return base.OnKeyDown(e);
+        }
+
+        protected virtual void OnExit() => this.Exit();
     }
 }

--- a/Circle.Game/Screens/ICircleScreen.cs
+++ b/Circle.Game/Screens/ICircleScreen.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using osu.Framework.Screens;
+﻿using osu.Framework.Screens;
 
 namespace Circle.Game.Screens
 {

--- a/Circle.Game/Screens/ICircleScreen.cs
+++ b/Circle.Game/Screens/ICircleScreen.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using osu.Framework.Screens;
+
+namespace Circle.Game.Screens
+{
+    public interface ICircleScreen : IScreen
+    {
+        bool BlockExit { get; }
+
+        string Header { get; }
+    }
+}

--- a/Circle.Game/Screens/MainScreen.cs
+++ b/Circle.Game/Screens/MainScreen.cs
@@ -1,3 +1,5 @@
+using System;
+using Circle.Game.Screens.Setting;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -6,6 +8,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Input.Events;
+using osu.Framework.Screens;
 using osuTK;
 using osuTK.Graphics;
 
@@ -13,6 +16,10 @@ namespace Circle.Game.Screens
 {
     public class MainScreen : CircleScreen
     {
+        public override string Header => "Circle";
+
+        public override bool BlockExit => true;
+
         [BackgroundDependencyLoader]
         private void load(LargeTextureStore textures)
         {
@@ -26,7 +33,7 @@ namespace Circle.Game.Screens
                 },
                 new SpriteText
                 {
-                    Text = "Circle",
+                    Text = Header,
                     Margin = new MarginPadding { Top = 60, Left = 60 },
                     Font = FontUsage.Default.With(size: 40)
                 }.WithEffect(new GlowEffect
@@ -49,7 +56,8 @@ namespace Circle.Game.Screens
                         },
                         new IconWithTextButton("settings")
                         {
-                            Icon = FontAwesome.Solid.Cog
+                            Icon = FontAwesome.Solid.Cog,
+                            Action = () => this.Push(new SettingsScreen())
                         },
                         new IconWithTextButton("exit")
                         {
@@ -70,7 +78,7 @@ namespace Circle.Game.Screens
                 set => icon.Icon = value;
             }
 
-            // public Action Action { get; set; }
+            public Action Action { get; set; }
 
             public IconWithTextButton(string text = @"")
             {
@@ -137,7 +145,7 @@ namespace Circle.Game.Screens
             protected override bool OnClick(ClickEvent e)
             {
                 Child.FlashColour(Color4.DarkGray, 250, Easing.InQuad);
-                // Action?.Invoke();
+                Action?.Invoke();
 
                 return base.OnClick(e);
             }

--- a/Circle.Game/Screens/ScreenHeader.cs
+++ b/Circle.Game/Screens/ScreenHeader.cs
@@ -11,30 +11,32 @@ namespace Circle.Game.Screens
 {
     public class ScreenHeader : CompositeDrawable
     {
-        public const int MARGIN = 60;
+        public const int MARGIN = 30;
 
-        public float DrawnHeight { get; }
-
-        public ScreenHeader(string name)
+        public ScreenHeader(CircleScreen screen)
         {
-            Margin = new MarginPadding { Top = MARGIN, Bottom = 10 };
+            Margin = new MarginPadding { Top = MARGIN, Left = 30, Bottom = 10 };
+            AutoSizeAxes = Axes.Both;
             InternalChild = new FillFlowContainer
             {
                 Direction = FillDirection.Horizontal,
-                Spacing = new Vector2(10),
-                AutoSizeAxes = Axes.Y,
-                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Both,
                 Children = new Drawable[]
                 {
                     new IconButton
                     {
                         Icon = FontAwesome.Solid.AngleLeft,
-                        Size = new Vector2(30)
+                        Size = new Vector2(30),
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        Action = () => screen.OnExit()
                     },
                     new SpriteText
                     {
-                        Text = name,
-                        Font = FontUsage.Default.With(size: 40)
+                        Text = screen.Header,
+                        Font = FontUsage.Default.With(size: 40),
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft
                     }.WithEffect(new GlowEffect
                     {
                         PadExtent = true,
@@ -43,8 +45,6 @@ namespace Circle.Game.Screens
                     })
                 }
             };
-
-            DrawnHeight = MARGIN + DrawHeight + 10;
         }
     }
 }

--- a/Circle.Game/Screens/ScreenHeader.cs
+++ b/Circle.Game/Screens/ScreenHeader.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Circle.Game.Graphics.UserInterface;
+﻿using Circle.Game.Graphics.UserInterface;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;

--- a/Circle.Game/Screens/ScreenHeader.cs
+++ b/Circle.Game/Screens/ScreenHeader.cs
@@ -28,7 +28,7 @@ namespace Circle.Game.Screens
                         Size = new Vector2(30),
                         Anchor = Anchor.CentreLeft,
                         Origin = Anchor.CentreLeft,
-                        Action = () => screen.OnExit()
+                        Action = screen.OnExit
                     },
                     new SpriteText
                     {

--- a/Circle.Game/Screens/ScreenHeader.cs
+++ b/Circle.Game/Screens/ScreenHeader.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Circle.Game.Graphics.UserInterface;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Effects;
+using osu.Framework.Graphics.Sprites;
+using osuTK;
+using osuTK.Graphics;
+
+namespace Circle.Game.Screens
+{
+    public class ScreenHeader : CompositeDrawable
+    {
+        public const int MARGIN = 60;
+
+        public float DrawnHeight { get; }
+
+        public ScreenHeader(string name)
+        {
+            Margin = new MarginPadding { Top = MARGIN, Bottom = 10 };
+            InternalChild = new FillFlowContainer
+            {
+                Direction = FillDirection.Horizontal,
+                Spacing = new Vector2(10),
+                AutoSizeAxes = Axes.Y,
+                RelativeSizeAxes = Axes.X,
+                Children = new Drawable[]
+                {
+                    new IconButton
+                    {
+                        Icon = FontAwesome.Solid.AngleLeft,
+                        Size = new Vector2(30)
+                    },
+                    new SpriteText
+                    {
+                        Text = name,
+                        Font = FontUsage.Default.With(size: 40)
+                    }.WithEffect(new GlowEffect
+                    {
+                        PadExtent = true,
+                        Colour = Color4.White,
+                        BlurSigma = new Vector2(10)
+                    })
+                }
+            };
+
+            DrawnHeight = MARGIN + DrawHeight + 10;
+        }
+    }
+}

--- a/Circle.Game/Screens/Setting/Sections/DebugSection.cs
+++ b/Circle.Game/Screens/Setting/Sections/DebugSection.cs
@@ -1,0 +1,36 @@
+﻿using Circle.Game.Configuration;
+using Circle.Game.Graphics.UserInterface;
+using Crcle.Game.Overlays.Settings;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Platform;
+
+namespace Circle.Game.Screens.Setting.Sections
+{
+    public class DebugSection : SettingsSection
+    {
+        public override string Header => "Debug";
+
+        [BackgroundDependencyLoader]
+        private void load(CircleGameBase gameBase, GameHost host, CircleConfigManager config)
+        {
+            FlowContent.AddRange(new Drawable[]
+            {
+                new BoxButton
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Text = "Clear all caches",
+                    Action = host.Collect
+                }
+            });
+            FlowContent.Add(new SpriteText
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Text = $"running on osu!framework {gameBase.FrameworkVersion}"
+            });
+        }
+    }
+}

--- a/Circle.Game/Screens/Setting/Sections/DebugSection.cs
+++ b/Circle.Game/Screens/Setting/Sections/DebugSection.cs
@@ -1,6 +1,5 @@
 ﻿using Circle.Game.Configuration;
 using Circle.Game.Graphics.UserInterface;
-using Crcle.Game.Overlays.Settings;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;

--- a/Circle.Game/Screens/Setting/SettingsScreen.cs
+++ b/Circle.Game/Screens/Setting/SettingsScreen.cs
@@ -20,42 +20,38 @@ namespace Circle.Game.Screens.Setting
         {
             InternalChildren = new Drawable[]
             {
-                new SpriteText
-                {
-                    Margin = new MarginPadding(60),
-                    Text = Header,
-                    Font = FontUsage.Default.With(size: 40)
-                }.WithEffect(new GlowEffect
-                {
-                    BlurSigma = new Vector2(10),
-                    PadExtent = true,
-                }),
+                new ScreenHeader(this),
                 new Container
                 {
-                    Margin = new MarginPadding { Top = 130, Left = 80 },
-                    Size = new Vector2(500, Y),
+                    Margin = new MarginPadding { Left = 80 },
+                    Padding = new MarginPadding { Vertical = 130 },
+                    Width = 500,
                     RelativeSizeAxes = Axes.Y,
-                    Masking = true,
-                    CornerRadius = 7,
-                    Children = new Drawable[]
+                    Child = new Container
                     {
-                        new Box
+                        RelativeSizeAxes = Axes.Both,
+                        Masking = true,
+                        CornerRadius = 5,
+                        Children = new Drawable[]
                         {
-                            Colour = Color4.White.Opacity(0.2f),
-                            RelativeSizeAxes = Axes.Both
-                        },
-                        new CircleScrollContainer
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                            Child = new FillFlowContainer
+                            new Box
                             {
-                                Direction = FillDirection.Vertical,
-                                Spacing = new Vector2(10),
-                                AutoSizeAxes = Axes.Y,
-                                RelativeSizeAxes = Axes.X,
-                                Children = new Drawable[]
+                                Colour = Color4.White.Opacity(0.2f),
+                                RelativeSizeAxes = Axes.Both
+                            },
+                            new CircleScrollContainer
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Child = new FillFlowContainer
                                 {
-                                    new DebugSection()
+                                    Direction = FillDirection.Vertical,
+                                    Spacing = new Vector2(10),
+                                    AutoSizeAxes = Axes.Y,
+                                    RelativeSizeAxes = Axes.X,
+                                    Children = new Drawable[]
+                                    {
+                                        new DebugSection()
+                                    }
                                 }
                             }
                         }

--- a/Circle.Game/Screens/Setting/SettingsScreen.cs
+++ b/Circle.Game/Screens/Setting/SettingsScreen.cs
@@ -1,14 +1,11 @@
-﻿using System;
+﻿using Circle.Game.Graphics.UserInterface;
 using Circle.Game.Screens.Setting.Sections;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Graphics.Sprites;
 using osuTK;
 using osuTK.Graphics;
-using osu.Framework.Extensions.Color4Extensions;
-using Circle.Game.Graphics.UserInterface;
 
 namespace Circle.Game.Screens.Setting
 {

--- a/Circle.Game/Screens/Setting/SettingsScreen.cs
+++ b/Circle.Game/Screens/Setting/SettingsScreen.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using Circle.Game.Screens.Setting.Sections;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Effects;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osuTK;
+using osuTK.Graphics;
+using osu.Framework.Extensions.Color4Extensions;
+using Circle.Game.Graphics.UserInterface;
+
+namespace Circle.Game.Screens.Setting
+{
+    public class SettingsScreen : CircleScreen
+    {
+        public override string Header => "settings";
+
+        public SettingsScreen()
+        {
+            InternalChildren = new Drawable[]
+            {
+                new SpriteText
+                {
+                    Margin = new MarginPadding(60),
+                    Text = Header,
+                    Font = FontUsage.Default.With(size: 40)
+                }.WithEffect(new GlowEffect
+                {
+                    BlurSigma = new Vector2(10),
+                    PadExtent = true,
+                }),
+                new Container
+                {
+                    Margin = new MarginPadding { Top = 130, Left = 80 },
+                    Size = new Vector2(500, Y),
+                    RelativeSizeAxes = Axes.Y,
+                    Masking = true,
+                    CornerRadius = 7,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            Colour = Color4.White.Opacity(0.2f),
+                            RelativeSizeAxes = Axes.Both
+                        },
+                        new CircleScrollContainer
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Child = new FillFlowContainer
+                            {
+                                Direction = FillDirection.Vertical,
+                                Spacing = new Vector2(10),
+                                AutoSizeAxes = Axes.Y,
+                                RelativeSizeAxes = Axes.X,
+                                Children = new Drawable[]
+                                {
+                                    new DebugSection()
+                                }
+                            }
+                        }
+                    }
+                },
+            };
+        }
+    }
+}

--- a/Circle.Game/Screens/Setting/SettingsSection.cs
+++ b/Circle.Game/Screens/Setting/SettingsSection.cs
@@ -1,0 +1,70 @@
+﻿using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osuTK;
+using osuTK.Graphics;
+
+namespace Crcle.Game.Overlays.Settings
+{
+    public abstract class SettingsSection : Container
+    {
+        protected FillFlowContainer FlowContent;
+
+        public abstract string Header { get; }
+
+        private const int header_size = 30;
+        private const int margin = 20;
+
+        public const int CONTENT_MARGINS = 15;
+
+        protected SettingsSection()
+        {
+            Margin = new MarginPadding { Bottom = margin };
+            AutoSizeAxes = Axes.Y;
+            RelativeSizeAxes = Axes.X;
+
+            FlowContent = new FillFlowContainer
+            {
+                Margin = new MarginPadding { Top = header_size + margin },
+                Padding = new MarginPadding { Horizontal = CONTENT_MARGINS },
+                Direction = FillDirection.Vertical,
+                AutoSizeAxes = Axes.Y,
+                RelativeSizeAxes = Axes.X,
+                Spacing = new Vector2(5)
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            AddRangeInternal(new Drawable[]
+            {
+                new Box
+                {
+                    Colour = Color4.Black,
+                    Height = 3,
+                    RelativeSizeAxes = Axes.X,
+                    Alpha = 0.5f,
+                },
+                new Container
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Margin = new MarginPadding { Top = 20 },
+                    Children = new Drawable[]
+                    {
+                        new SpriteText
+                        {
+                            Font = FontUsage.Default.With(size: header_size),
+                            Text = Header,
+                            Margin = new MarginPadding { Horizontal = CONTENT_MARGINS },
+                        },
+                        FlowContent
+                    }
+                }
+            });
+        }
+    }
+}

--- a/Circle.Game/Screens/Setting/SettingsSection.cs
+++ b/Circle.Game/Screens/Setting/SettingsSection.cs
@@ -6,7 +6,7 @@ using osu.Framework.Graphics.Sprites;
 using osuTK;
 using osuTK.Graphics;
 
-namespace Crcle.Game.Overlays.Settings
+namespace Circle.Game.Screens.Setting
 {
     public abstract class SettingsSection : Container
     {

--- a/Circle.iOS/AppDelegate.cs
+++ b/Circle.iOS/AppDelegate.cs
@@ -1,10 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using Circle.Game;
-using Foundation;
-using osu.Framework.iOS;
-
 namespace Circle.iOS
 {
     [Register("AppDelegate")]


### PR DESCRIPTION
- [ ] 설정 섹션 추가.
- [ ] 테스트 장면 추가.

_화면을 캐시해야 할지 고민중._

# 주요 변경 사항
## GlowEffect가 포함된 헤더를 사용할 때 `SpriteText`대신 `ScreenHeader`를 사용해야 함.
`ScreenHeader`는 뒤로가기, 헤더 표시를 사용할 수 있고, 생산성을 높일 수 있음.

## `CircleScreen`나가기를 막으려면 `BlockExit`를 사용해야 함.
https://github.com/ojh050118/Circle/blob/8eee01462c6be3277f6befe00ed2e2aa6d8f8aa1/Circle.Game/Screens/CircleScreen.cs#L10
기본값은 `false`.

