### PR TITLE
Make `Background` and `CircleScreen` work organically

### DIFF
--- a/Circle.Game.Tests/CircleTestBrowser.cs
+++ b/Circle.Game.Tests/CircleTestBrowser.cs
@@ -11,6 +11,7 @@ namespace Circle.Game.Tests
     public class CircleTestBrowser : CircleGameBase
     {
         private DependencyContainer dependencies;
+
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent) =>
             dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
 

--- a/Circle.Game.Tests/CircleTestBrowser.cs
+++ b/Circle.Game.Tests/CircleTestBrowser.cs
@@ -1,4 +1,6 @@
 using Circle.Game.Graphics.UserInterface;
+using Circle.Game.Overlays;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Platform;
@@ -8,6 +10,17 @@ namespace Circle.Game.Tests
 {
     public class CircleTestBrowser : CircleGameBase
     {
+        private DependencyContainer dependencies;
+        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent) =>
+            dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            dependencies.CacheAs(new Background());
+            dependencies.CacheAs(new DialogOverlay());
+        }
+
         protected override void LoadComplete()
         {
             base.LoadComplete();
@@ -16,7 +29,7 @@ namespace Circle.Game.Tests
             {
                 new Background(textureName: "Duelyst")
                 {
-                    Alpha = 0.5f,
+                    Alpha = 0.4f,
                 },
                 new TestBrowser("Circle"),
                 new CursorContainer()

--- a/Circle.Game.Tests/Visual/UserInterface/TestSceneBackground.cs
+++ b/Circle.Game.Tests/Visual/UserInterface/TestSceneBackground.cs
@@ -1,4 +1,5 @@
 ﻿using Circle.Game.Graphics.UserInterface;
+using osu.Framework.Graphics;
 using osuTK;
 
 namespace Circle.Game.Tests.Visual.UserInterface
@@ -9,10 +10,17 @@ namespace Circle.Game.Tests.Visual.UserInterface
         {
             Background background;
 
-            Add(background = new Background(textureName: "Duelyst"));
+            Add(background = new Background(textureName: "Duelyst")
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+            });
             AddSliderStep("BlurSIgma", 0, 10f, 0, v => background.BlurSigma.Value = new Vector2(v));
+            AddStep("Scale to 0.6", () => background.Scale = new Vector2(0.6f));
+            AddStep("Scale to 1", () => background.Scale = new Vector2(1));
             AddStep("BlurTo 10", () => background.BlurTo(new Vector2(10), 500));
             AddStep("BlurTo 0", () => background.BlurTo(Vector2.Zero, 500));
+
         }
     }
 }

--- a/Circle.Game.Tests/Visual/UserInterface/TestSceneBackground.cs
+++ b/Circle.Game.Tests/Visual/UserInterface/TestSceneBackground.cs
@@ -20,7 +20,6 @@ namespace Circle.Game.Tests.Visual.UserInterface
             AddStep("Scale to 1", () => background.Scale = new Vector2(1));
             AddStep("BlurTo 10", () => background.BlurTo(new Vector2(10), 500));
             AddStep("BlurTo 0", () => background.BlurTo(Vector2.Zero, 500));
-
         }
     }
 }

--- a/Circle.Game/CircleGame.cs
+++ b/Circle.Game/CircleGame.cs
@@ -2,10 +2,8 @@
 using Circle.Game.Overlays;
 using Circle.Game.Screens;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Screens;
-using osuTK;
 
 namespace Circle.Game
 {

--- a/Circle.Game/CircleGame.cs
+++ b/Circle.Game/CircleGame.cs
@@ -25,11 +25,7 @@ namespace Circle.Game
         {
             Children = new Drawable[]
             {
-                background = new Background(textureName: "Duelyst")
-                {
-                    Alpha = 0.3f,
-                    BlurSigma = new Bindable<Vector2>(new Vector2(10))
-                },
+                background = new Background(textureName: "Duelyst"),
                 screenStack = new ScreenStack { RelativeSizeAxes = Axes.Both },
                 dialog = new DialogOverlay()
             };

--- a/Circle.Game/Graphics/UserInterface/Background.cs
+++ b/Circle.Game/Graphics/UserInterface/Background.cs
@@ -6,6 +6,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osuTK;
@@ -17,6 +18,7 @@ namespace Circle.Game.Graphics.UserInterface
     {
         private BufferedContainer bufferedContainer;
         private BufferedContainer newBufferedContainer;
+        private Box dim;
 
         public readonly Sprite Sprite;
 
@@ -34,17 +36,26 @@ namespace Circle.Game.Graphics.UserInterface
             this.source = source;
             this.textureName = textureName;
             RelativeSizeAxes = Axes.Both;
-            AddInternal(Sprite = new Sprite
+            AddInternal(bufferedContainer = new BufferedContainer(cachedFrameBuffer: true)
             {
-                RelativeSizeAxes = Axes.Both,
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
-                FillMode = FillMode.Fill,
+                RelativeSizeAxes = Axes.Both,
+                RedrawOnScale = false,
+                Masking = true,
+                Child = Sprite = new Sprite
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    FillMode = FillMode.Fill,
+                },
+                
             });
         }
 
         [BackgroundDependencyLoader]
-        private void load(LargeTextureStore textures, MonitoredLargeTextureStore monitoredTextures, CircleConfigManager config)
+        private void load(LargeTextureStore textures, MonitoredLargeTextureStore monitoredTextures)
         {
             largeTexture = textures;
             monitoredLargeTexture = monitoredTextures;
@@ -58,31 +69,30 @@ namespace Circle.Game.Graphics.UserInterface
 
         public void BlurTo(Vector2 newBlurSigma, double duration = 0, Easing easing = Easing.None)
         {
-            if (bufferedContainer == null && newBlurSigma != Vector2.Zero)
-            {
-                RemoveInternal(Sprite);
+            bufferedContainer.BlurTo(newBlurSigma, duration, easing);
+            newBufferedContainer?.BlurTo(newBlurSigma, duration, easing);
 
-                AddInternal(bufferedContainer = new BufferedContainer
+        }
+
+        public void ColorTo(Color4 color4, double duration = 0, Easing easing = Easing.None)
+        {
+            bufferedContainer.FadeColour(color4, duration, easing);
+        }
+
+        public void DimTo(float newAlpha, double duration = 0, Easing easing = Easing.None)
+        {
+            if (dim == null)
+            {
+                AddInternal(dim = new Box
                 {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
                     RelativeSizeAxes = Axes.Both,
-                    RedrawOnScale = false,
-                    Child = Sprite,
-                    Masking = true,
+                    Colour = Color4.Black,
+                    Alpha = 0
                 });
             }
 
-            if (bufferedContainer != null)
-            {
-                bufferedContainer.BlurTo(newBlurSigma, duration, easing);
-                newBufferedContainer?.BlurTo(newBlurSigma, duration, easing);
-            }
-        }
-
-        public void ColorTo(Color4 color4, double duration, Easing easing = Easing.None)
-        {
-            bufferedContainer.FadeColour(color4, duration, easing);
+            if (dim != null)
+                dim.FadeTo(newAlpha, duration, easing);
         }
 
         private async Task<Sprite> loadTexture(TextureSource source, string textureName)
@@ -111,7 +121,7 @@ namespace Circle.Game.Graphics.UserInterface
             }
         }
 
-        public void TextureFadeTo(TextureSource source, string textureName, double duration, Easing easing = Easing.None)
+        public void FadeTextureTo(TextureSource source, string textureName, double duration, Easing easing = Easing.None)
         {
             if (Sprite is null)
                 return;
@@ -123,7 +133,7 @@ namespace Circle.Game.Graphics.UserInterface
 
             if (source == TextureSource.Internal)
             {
-                Schedule(() => LoadComponentAsync(newContainer = new BufferedContainer
+                LoadComponentAsync(newContainer = new BufferedContainer(cachedFrameBuffer: true)
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
@@ -139,11 +149,11 @@ namespace Circle.Game.Graphics.UserInterface
                     newContainer.BlurTo(BlurSigma.Value);
                     newContainer.FadeIn(duration, easing);
                     Scheduler.AddDelayed(() => bufferedContainer = newContainer, duration);
-                }));
+                });
             }
             else
             {
-                Schedule(() => LoadComponentAsync(newContainer = new BufferedContainer
+                LoadComponentAsync(newContainer = new BufferedContainer(cachedFrameBuffer: true)
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
@@ -159,7 +169,7 @@ namespace Circle.Game.Graphics.UserInterface
                     newContainer.BlurTo(BlurSigma.Value);
                     newContainer.FadeIn(duration, easing);
                     Scheduler.AddDelayed(() => bufferedContainer = newContainer, duration);
-                }));
+                });
             }
         }
     }

--- a/Circle.Game/Graphics/UserInterface/Background.cs
+++ b/Circle.Game/Graphics/UserInterface/Background.cs
@@ -1,6 +1,5 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
-using Circle.Game.Configuration;
 using Circle.Game.IO;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -50,7 +49,6 @@ namespace Circle.Game.Graphics.UserInterface
                     Origin = Anchor.Centre,
                     FillMode = FillMode.Fill,
                 },
-                
             });
         }
 
@@ -71,7 +69,6 @@ namespace Circle.Game.Graphics.UserInterface
         {
             bufferedContainer.BlurTo(newBlurSigma, duration, easing);
             newBufferedContainer?.BlurTo(newBlurSigma, duration, easing);
-
         }
 
         public void ColorTo(Color4 color4, double duration = 0, Easing easing = Easing.None)
@@ -91,8 +88,7 @@ namespace Circle.Game.Graphics.UserInterface
                 });
             }
 
-            if (dim != null)
-                dim.FadeTo(newAlpha, duration, easing);
+            dim?.FadeTo(newAlpha, duration, easing);
         }
 
         private async Task<Sprite> loadTexture(TextureSource source, string textureName)

--- a/Circle.Game/Screens/CircleScreen.cs
+++ b/Circle.Game/Screens/CircleScreen.cs
@@ -1,7 +1,6 @@
 ﻿using Circle.Game.Graphics.UserInterface;
 using Circle.Game.Input;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
@@ -25,7 +24,6 @@ namespace Circle.Game.Screens
         {
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
-
         }
 
         public override void OnEntering(IScreen last)

--- a/Circle.Game/Screens/CircleScreen.cs
+++ b/Circle.Game/Screens/CircleScreen.cs
@@ -1,8 +1,12 @@
-﻿using Circle.Game.Input;
+﻿using Circle.Game.Graphics.UserInterface;
+using Circle.Game.Input;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Framework.Screens;
+using osuTK;
 
 namespace Circle.Game.Screens
 {
@@ -12,23 +16,40 @@ namespace Circle.Game.Screens
 
         public virtual string Header => string.Empty;
 
+        public virtual bool FadeBackground => true;
+
+        [Resolved]
+        private Background background { get; set; }
+
         public CircleScreen()
         {
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
+
         }
 
         public override void OnEntering(IScreen last)
         {
             base.OnEntering(last);
-
             X = DrawWidth;
             this.MoveToX(0, 1000, Easing.OutPow10);
+
+            if (FadeBackground)
+            {
+                background.DimTo(0.5f, 1000, Easing.OutPow10);
+                background.BlurTo(new Vector2(10), 1000, Easing.OutPow10);
+            }
         }
 
         public override bool OnExiting(IScreen next)
         {
             this.MoveToX(DrawWidth, 1000, Easing.OutPow10);
+
+            if (FadeBackground)
+            {
+                background.DimTo(0, 1000, Easing.OutPow10);
+                background.BlurTo(Vector2.Zero, 1000, Easing.OutPow10);
+            }
 
             return base.OnExiting(next);
         }
@@ -37,7 +58,6 @@ namespace Circle.Game.Screens
         {
             base.OnResuming(last);
 
-            X = DrawWidth;
             this.MoveToX(0, 1000, Easing.OutPow10);
         }
 
@@ -45,7 +65,7 @@ namespace Circle.Game.Screens
         {
             base.OnSuspending(next);
 
-            this.MoveToX(DrawWidth, 1000, Easing.OutPow10);
+            this.MoveToX(-DrawWidth * 0.5f, 2500, Easing.OutPow10);
         }
 
         public virtual bool OnPressed(KeyBindingPressEvent<InputAction> e)

--- a/Circle.Game/Screens/Loader.cs
+++ b/Circle.Game/Screens/Loader.cs
@@ -7,9 +7,9 @@ using osu.Framework.Threading;
 
 namespace Circle.Game.Screens
 {
-    public class Loader : CircleScreen
+    public class Loader : Screen
     {
-        private Screen mainScreen;
+        private CircleScreen mainScreen;
 
         private LoadingSpinner spinner;
         private ScheduledDelegate spinnerShow;

--- a/Circle.Game/Screens/MainScreen.cs
+++ b/Circle.Game/Screens/MainScreen.cs
@@ -23,20 +23,16 @@ namespace Circle.Game.Screens
 
         public override bool BlockExit => true;
 
+        public override bool FadeBackground => false;
+
         [Resolved]
         private DialogOverlay dialog { get; set; }
 
-        [BackgroundDependencyLoader(true)]
-        private void load(LargeTextureStore textures, CircleGameBase game, Background background = null)
+        [BackgroundDependencyLoader]
+        private void load()
         {
             InternalChildren = new Drawable[]
             {
-                new Sprite
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Texture = textures.Get("Duelyst"),
-                    FillMode = FillMode.Fill
-                },
                 new SpriteText
                 {
                     Text = Header,

--- a/Circle.Game/Screens/MainScreen.cs
+++ b/Circle.Game/Screens/MainScreen.cs
@@ -9,7 +9,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Graphics.Textures;
 using osu.Framework.Input.Events;
 using osu.Framework.Screens;
 using osuTK;

--- a/Circle.Game/Screens/Setting/SettingsScreen.cs
+++ b/Circle.Game/Screens/Setting/SettingsScreen.cs
@@ -15,7 +15,7 @@ namespace Circle.Game.Screens.Setting
 
         public SettingsScreen()
         {
-            InternalChildren = new Drawable[]
+            AddRangeInternal(new Drawable[]
             {
                 new ScreenHeader(this),
                 new Container
@@ -56,7 +56,7 @@ namespace Circle.Game.Screens.Setting
                         }
                     }
                 },
-            };
+            });
         }
     }
 }


### PR DESCRIPTION
 `Background`와 `CircleScreen`을 유기적으로 동작하게 하기.

# 주요 변경 사항
## `CircleScreen`에 `FadeBackground` 속성이 추가 되었습니다.
https://github.com/ojh050118/Circle/blob/35371e98091ff433f04070a7f32dd567d2d4cfca/Circle.Game/Screens/CircleScreen.cs#L18
기본값은 `true` 입니다.

## 그 외
TestBrowser에 `Background`와 `DialogOverlay` 캐시.