### PR TITLE
Fix to update 'BeatmapInfo' by comparing it correctly

### DIFF
--- a/Circle.Game.Tests/Visual/UserInterface/TestSceneBackground.cs
+++ b/Circle.Game.Tests/Visual/UserInterface/TestSceneBackground.cs
@@ -32,7 +32,7 @@ namespace Circle.Game.Tests.Visual.UserInterface
                 PlaceholderText = "External texture name",
                 Size = new Vector2(200, 30)
             });
-            
+
             AddLabel("Scale");
             AddStep("Scale to 0.6", () => background.Scale = new Vector2(0.6f));
             AddStep("Scale to 1", () => background.Scale = new Vector2(1));

--- a/Circle.Game.Tests/Visual/UserInterface/TestSceneBackground.cs
+++ b/Circle.Game.Tests/Visual/UserInterface/TestSceneBackground.cs
@@ -1,6 +1,7 @@
 ﻿using Circle.Game.Graphics.UserInterface;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.UserInterface;
 using osuTK;
 using osuTK.Graphics;
 
@@ -11,6 +12,8 @@ namespace Circle.Game.Tests.Visual.UserInterface
         public TestSceneBackground()
         {
             Background background;
+            BasicTextBox textBox;
+            double fadeDuration = 0;
 
             Add(new Box
             {
@@ -22,12 +25,25 @@ namespace Circle.Game.Tests.Visual.UserInterface
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
             });
-            AddSliderStep("BlurSIgma", 0, 10f, 0, v => background.BlurSigma = new Vector2(v));
+            Add(textBox = new BasicTextBox
+            {
+                Anchor = Anchor.BottomLeft,
+                Origin = Anchor.BottomLeft,
+                PlaceholderText = "External texture name",
+                Size = new Vector2(200, 30)
+            });
+            
+            AddLabel("Scale");
             AddStep("Scale to 0.6", () => background.Scale = new Vector2(0.6f));
             AddStep("Scale to 1", () => background.Scale = new Vector2(1));
+            AddLabel("Blur");
+            AddSliderStep("BlurSIgma", 0, 10f, 0, v => background.BlurSigma = new Vector2(v));
             AddStep("BlurTo 10", () => background.BlurTo(new Vector2(10), 500));
             AddStep("BlurTo 0", () => background.BlurTo(Vector2.Zero, 500));
-            AddStep("Fade texture", () => background.FadeTextureTo(TextureSource.Internal, "Duelyst", 1000));
+            AddLabel("Fade texture");
+            AddSliderStep<double>("Duration", 0, 2000, 1000, v => fadeDuration = v);
+            AddStep("Fade texture to Duelyst", () => background.FadeTextureTo(TextureSource.Internal, "Duelyst", fadeDuration));
+            AddStep("Fade texture to external texture", () => background.FadeTextureTo(TextureSource.External, textBox.Text, fadeDuration));
         }
     }
 }

--- a/Circle.Game/Beatmap/BeatmapStorage.cs
+++ b/Circle.Game/Beatmap/BeatmapStorage.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using Newtonsoft.Json;
 using osu.Framework.Graphics;
@@ -48,7 +49,17 @@ namespace Circle.Game.Beatmap
     {
         public float[] Angles;
         public Settings Settings;
-        public List<Actions> Actions;
+        public Actions[] Actions;
+
+        public static bool operator ==(BeatmapInfo info1, BeatmapInfo info2) => info1.Angles.Length == info2.Angles.Length && info1.Settings == info2.Settings && info1.Actions == info2.Actions;
+
+        public static bool operator !=(BeatmapInfo info1, BeatmapInfo info2) => info1.Angles.Length != info2.Angles.Length || info1.Settings != info2.Settings || info1.Actions != info2.Actions;
+
+        public bool Equals(BeatmapInfo other) => Equals(Angles, other.Angles) && Settings.Equals(other.Settings) && Equals(Actions, other.Actions);
+
+        public override bool Equals(object obj) => obj is BeatmapInfo other && Equals(other);
+
+        public override int GetHashCode() => HashCode.Combine(Angles, Settings, Actions);
     }
 
     public struct Settings
@@ -65,6 +76,60 @@ namespace Circle.Game.Beatmap
         public double Pitch;
         public string BackgroundTexture;
         public Easing PlanetEasing;
+
+        public static bool operator ==(Settings s1, Settings s2) => s1.Artist == s2.Artist &&
+                                                                    s1.Track == s2.Track &&
+                                                                    s1.Author == s2.Author &&
+                                                                    s1.SeparateCountdownTime == s2.SeparateCountdownTime &&
+                                                                    s1.PreviewTrackStart == s2.PreviewTrackStart &&
+                                                                    s1.BeatmapDesc == s2.BeatmapDesc &&
+                                                                    s1.BeatmapDifficulty == s2.BeatmapDifficulty &&
+                                                                    s1.BPM == s2.BPM &&
+                                                                    s1.BackgroundTexture == s2.BackgroundTexture &&
+                                                                    s1.PlanetEasing == s2.PlanetEasing;
+
+        public static bool operator !=(Settings s1, Settings s2) => s1.Artist != s2.Artist ||
+                                                                    s1.Track != s2.Track ||
+                                                                    s1.Author != s2.Author ||
+                                                                    s1.SeparateCountdownTime != s2.SeparateCountdownTime ||
+                                                                    s1.PreviewTrackStart != s2.PreviewTrackStart ||
+                                                                    s1.BeatmapDesc != s2.BeatmapDesc ||
+                                                                    s1.BeatmapDifficulty != s2.BeatmapDifficulty ||
+                                                                    s1.BPM != s2.BPM ||
+                                                                    s1.BackgroundTexture != s2.BackgroundTexture ||
+                                                                    s1.PlanetEasing != s2.PlanetEasing;
+
+        public bool Equals(Settings other) => Artist == other.Artist &&
+                                              Track == other.Track &&
+                                              Author == other.Author &&
+                                              SeparateCountdownTime == other.SeparateCountdownTime &&
+                                              PreviewTrackStart == other.PreviewTrackStart &&
+                                              BeatmapDesc == other.BeatmapDesc &&
+                                              BeatmapDifficulty == other.BeatmapDifficulty &&
+                                              BPM.Equals(other.BPM) && Offset.Equals(other.Offset) &&
+                                              Pitch.Equals(other.Pitch) &&
+                                              BackgroundTexture == other.BackgroundTexture &&
+                                              PlanetEasing == other.PlanetEasing;
+
+        public override bool Equals(object obj) => obj is Settings other && Equals(other);
+
+        public override int GetHashCode()
+        {
+            var hashCode = new HashCode();
+            hashCode.Add(Artist);
+            hashCode.Add(Track);
+            hashCode.Add(Author);
+            hashCode.Add(SeparateCountdownTime);
+            hashCode.Add(PreviewTrackStart);
+            hashCode.Add(BeatmapDesc);
+            hashCode.Add(BeatmapDifficulty);
+            hashCode.Add(BPM);
+            hashCode.Add(Offset);
+            hashCode.Add(Pitch);
+            hashCode.Add(BackgroundTexture);
+            hashCode.Add((int)PlanetEasing);
+            return hashCode.ToHashCode();
+        }
     }
 
     public struct Actions
@@ -76,9 +141,10 @@ namespace Circle.Game.Beatmap
     public struct Event
     {
         public EventType EventType;
-        public double ToBPM;
-        public bool IsRelativeTile;
-        public bool IsTwirl;
+        public SpeedType? SpeedType;
+        public float? BeatsPerMinute;
+        public float? BpmMultiplier;
+        public RelativeTo? RelativeTo;
     }
 
     public enum EventType
@@ -86,5 +152,19 @@ namespace Circle.Game.Beatmap
         Twirl,
         SetSpeed,
         MoveCamera
+    }
+
+    public enum SpeedType
+    {
+        Multiplier,
+        Bpm
+    }
+
+    public enum RelativeTo
+    {
+        Tile,
+        Player,
+        Global,
+        LastPosition
     }
 }

--- a/Circle.Game/Beatmap/BeatmapStorage.cs
+++ b/Circle.Game/Beatmap/BeatmapStorage.cs
@@ -50,13 +50,7 @@ namespace Circle.Game.Beatmap
         public Settings Settings;
         public Actions[] Actions;
 
-        public static bool operator ==(BeatmapInfo info1, BeatmapInfo info2) => info1.Angles.Length == info2.Angles.Length && info1.Settings == info2.Settings && info1.Actions == info2.Actions;
-
-        public static bool operator !=(BeatmapInfo info1, BeatmapInfo info2) => info1.Angles.Length != info2.Angles.Length || info1.Settings != info2.Settings || info1.Actions != info2.Actions;
-
-        public bool Equals(BeatmapInfo other) => Equals(Angles, other.Angles) && Settings.Equals(other.Settings) && Equals(Actions, other.Actions);
-
-        public override bool Equals(object obj) => obj is BeatmapInfo other && Equals(other);
+        public bool Equals(BeatmapInfo info) => Angles.Length == info.Angles.Length && Settings.Equals(info.Settings) && Actions == info.Actions;
     }
 
     public struct Settings
@@ -74,41 +68,18 @@ namespace Circle.Game.Beatmap
         public string BackgroundTexture;
         public Easing PlanetEasing;
 
-        public static bool operator ==(Settings s1, Settings s2) => s1.Artist == s2.Artist &&
-                                                                    s1.Track == s2.Track &&
-                                                                    s1.Author == s2.Author &&
-                                                                    s1.SeparateCountdownTime == s2.SeparateCountdownTime &&
-                                                                    s1.PreviewTrackStart == s2.PreviewTrackStart &&
-                                                                    s1.BeatmapDesc == s2.BeatmapDesc &&
-                                                                    s1.BeatmapDifficulty == s2.BeatmapDifficulty &&
-                                                                    s1.BPM == s2.BPM &&
-                                                                    s1.BackgroundTexture == s2.BackgroundTexture &&
-                                                                    s1.PlanetEasing == s2.PlanetEasing;
-
-        public static bool operator !=(Settings s1, Settings s2) => s1.Artist != s2.Artist ||
-                                                                    s1.Track != s2.Track ||
-                                                                    s1.Author != s2.Author ||
-                                                                    s1.SeparateCountdownTime != s2.SeparateCountdownTime ||
-                                                                    s1.PreviewTrackStart != s2.PreviewTrackStart ||
-                                                                    s1.BeatmapDesc != s2.BeatmapDesc ||
-                                                                    s1.BeatmapDifficulty != s2.BeatmapDifficulty ||
-                                                                    s1.BPM != s2.BPM ||
-                                                                    s1.BackgroundTexture != s2.BackgroundTexture ||
-                                                                    s1.PlanetEasing != s2.PlanetEasing;
-
-        public bool Equals(Settings other) => Artist == other.Artist &&
-                                              Track == other.Track &&
-                                              Author == other.Author &&
-                                              SeparateCountdownTime == other.SeparateCountdownTime &&
-                                              PreviewTrackStart == other.PreviewTrackStart &&
-                                              BeatmapDesc == other.BeatmapDesc &&
-                                              BeatmapDifficulty == other.BeatmapDifficulty &&
-                                              BPM.Equals(other.BPM) && Offset.Equals(other.Offset) &&
-                                              Pitch.Equals(other.Pitch) &&
-                                              BackgroundTexture == other.BackgroundTexture &&
-                                              PlanetEasing == other.PlanetEasing;
-
-        public override bool Equals(object obj) => obj is Settings other && Equals(other);
+        public bool Equals(Settings settings) => Artist == settings.Artist &&
+                                                 Track == settings.Track &&
+                                                 Author == settings.Author &&
+                                                 SeparateCountdownTime == settings.SeparateCountdownTime &&
+                                                 PreviewTrackStart == settings.PreviewTrackStart &&
+                                                 BeatmapDesc == settings.BeatmapDesc &&
+                                                 BeatmapDifficulty == settings.BeatmapDifficulty &&
+                                                 (int)BPM == (int)settings.BPM &&
+                                                 (int)Offset == (int)settings.Offset &&
+                                                 (int)Pitch == (int)settings.Pitch &&
+                                                 BackgroundTexture == settings.BackgroundTexture &&
+                                                 PlanetEasing == settings.PlanetEasing;
     }
 
     public struct Actions

--- a/Circle.Game/Beatmap/BeatmapStorage.cs
+++ b/Circle.Game/Beatmap/BeatmapStorage.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using Newtonsoft.Json;
 using osu.Framework.Graphics;
@@ -58,8 +57,6 @@ namespace Circle.Game.Beatmap
         public bool Equals(BeatmapInfo other) => Equals(Angles, other.Angles) && Settings.Equals(other.Settings) && Equals(Actions, other.Actions);
 
         public override bool Equals(object obj) => obj is BeatmapInfo other && Equals(other);
-
-        public override int GetHashCode() => HashCode.Combine(Angles, Settings, Actions);
     }
 
     public struct Settings
@@ -112,24 +109,6 @@ namespace Circle.Game.Beatmap
                                               PlanetEasing == other.PlanetEasing;
 
         public override bool Equals(object obj) => obj is Settings other && Equals(other);
-
-        public override int GetHashCode()
-        {
-            var hashCode = new HashCode();
-            hashCode.Add(Artist);
-            hashCode.Add(Track);
-            hashCode.Add(Author);
-            hashCode.Add(SeparateCountdownTime);
-            hashCode.Add(PreviewTrackStart);
-            hashCode.Add(BeatmapDesc);
-            hashCode.Add(BeatmapDifficulty);
-            hashCode.Add(BPM);
-            hashCode.Add(Offset);
-            hashCode.Add(Pitch);
-            hashCode.Add(BackgroundTexture);
-            hashCode.Add((int)PlanetEasing);
-            return hashCode.ToHashCode();
-        }
     }
 
     public struct Actions

--- a/Circle.Game/Beatmap/BeatmapStorage.cs
+++ b/Circle.Game/Beatmap/BeatmapStorage.cs
@@ -50,7 +50,7 @@ namespace Circle.Game.Beatmap
         public Settings Settings;
         public Actions[] Actions;
 
-        public bool Equals(BeatmapInfo info) => Angles.Length == info.Angles.Length && Settings.Equals(info.Settings) && Actions == info.Actions;
+        public bool Equals(BeatmapInfo info) => Angles?.Length == info.Angles?.Length && Settings.Equals(info.Settings) && Actions == info.Actions;
     }
 
     public struct Settings

--- a/Circle.Game/CircleGameBase.cs
+++ b/Circle.Game/CircleGameBase.cs
@@ -13,6 +13,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Performance;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.IO.Stores;
+using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osuTK;
 
@@ -105,6 +106,8 @@ namespace Circle.Game
             base.LoadComplete();
 
             applySettings();
+            WorkingBeatmap.ValueChanged += value =>
+                Logger.Log($"Beatmap changed: {value.OldValue.Settings.Author} - {value.OldValue.Settings.Track} ¡æ {value.NewValue.Settings.Author} - {value.NewValue.Settings.Track}.");
         }
 
         public override void SetHost(GameHost host)
@@ -116,7 +119,7 @@ namespace Circle.Game
             TrackedSettings = LocalConfig.CreateTrackedSettings();
             LocalConfig.LoadInto(TrackedSettings);
 
-            TrackedSettings.SettingChanged += setTeackedSettingChange;
+            TrackedSettings.SettingChanged += setTrackedSettingChange;
         }
 
         public void GracefullyExit()
@@ -144,7 +147,7 @@ namespace Circle.Game
             FrameStatistics.Value = fpsDisplay ? FrameStatisticsMode.Minimal : FrameStatisticsMode.None;
         }
 
-        private void setTeackedSettingChange(SettingDescription description)
+        private void setTrackedSettingChange(SettingDescription description)
         {
             switch (description.Name.ToString())
             {

--- a/Circle.Game/Graphics/UserInterface/Background.cs
+++ b/Circle.Game/Graphics/UserInterface/Background.cs
@@ -113,7 +113,7 @@ namespace Circle.Game.Graphics.UserInterface
             if (Sprite is null)
                 return;
 
-            LoadComponentAsync(newBufferedContainer = new BufferedContainer(cachedFrameBuffer: true)
+            AddInternal(newBufferedContainer = new BufferedContainer(cachedFrameBuffer: true)
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
@@ -122,18 +122,15 @@ namespace Circle.Game.Graphics.UserInterface
                 RedrawOnScale = false,
                 Masking = true,
                 Child = loadTexture(source, textureName),
-            }, _ =>
-            {
-                AddInternal(newBufferedContainer);
-                if (dim != null)
-                    ChangeInternalChildDepth(dim, -1);
+            });
+            if (dim != null)
+                ChangeInternalChildDepth(dim, -1);
 
-                newBufferedContainer.BlurSigma = BlurSigma;
-                newBufferedContainer.FadeIn(duration, easing).Then().Schedule(() =>
-                {
-                    RemoveInternal(InternalChildren.First());
-                    bufferedContainer = newBufferedContainer;
-                });
+            newBufferedContainer.BlurSigma = BlurSigma;
+            newBufferedContainer.FadeIn(duration, easing).Then().Schedule(() =>
+            {
+                RemoveInternal(InternalChildren.First());
+                bufferedContainer = newBufferedContainer;
             });
         }
     }

--- a/Circle.Game/Screens/Select/BeatmapCarousel.cs
+++ b/Circle.Game/Screens/Select/BeatmapCarousel.cs
@@ -81,7 +81,7 @@ namespace Circle.Game.Screens.Select
 
                         Schedule(() =>
                         {
-                            if (working.Value != item.BeatmapInfo)
+                            if (working.Value.Equals(item.BeatmapInfo))
                             {
                                 working.Value = item.BeatmapInfo;
                                 music.Play();
@@ -114,7 +114,7 @@ namespace Circle.Game.Screens.Select
 
             foreach (var item in Scroll.Child.Children)
             {
-                if (item.BeatmapInfo == working.Value)
+                if (item.BeatmapInfo.Equals(working.Value))
                 {
                     item.State.Value = CarouselItemState.Selected;
                     break;

--- a/Circle.Game/Screens/Select/BeatmapCarousel.cs
+++ b/Circle.Game/Screens/Select/BeatmapCarousel.cs
@@ -15,7 +15,7 @@ namespace Circle.Game.Screens.Select
 {
     public class BeatmapCarousel : CompositeDrawable
     {
-        protected readonly CarouselScrollContiner Scroll;
+        protected readonly CarouselScrollContainer Scroll;
 
         private CarouselItem selectedCarouselItem => Scroll?.Child.Children.FirstOrDefault(i => i.State.Value == CarouselItemState.Selected);
 
@@ -34,7 +34,7 @@ namespace Circle.Game.Screens.Select
             RelativeSizeAxes = Axes.Both;
             InternalChildren = new Drawable[]
             {
-                Scroll = new CarouselScrollContiner
+                Scroll = new CarouselScrollContainer
                 {
                     RelativeSizeAxes = Axes.Both,
                     Masking = false,
@@ -79,16 +79,19 @@ namespace Circle.Game.Screens.Select
                         else
                             background.FadeTextureTo(TextureSource.Internal, "Duelyst", 1000, Easing.OutPow10);
 
-                        if (working.Value.Settings.Track != item.BeatmapInfo.Settings.Track)
+                        Schedule(() =>
                         {
-                            working.Value = item.BeatmapInfo;
-                            music.Play();
-                        }
+                            if (working.Value != item.BeatmapInfo)
+                            {
+                                working.Value = item.BeatmapInfo;
+                                music.Play();
+                            }
+                        });
 
                         foreach (var item2 in Scroll.Child.Children)
                         {
                             if (item2 != item)
-                                item2.State.Value = CarouselItemState.Collapsed;
+                                item2.State.Value = CarouselItemState.NotSelected;
                         }
                     }
                 };
@@ -102,7 +105,7 @@ namespace Circle.Game.Screens.Select
             if (Scroll.Child.Children.Count == 0)
                 return;
 
-            if (working.Value.Settings.Track == string.Empty || working.Value.Settings.Track is null)
+            if (string.IsNullOrEmpty(working.Value.Settings.Track))
             {
                 var idx = new Random().Next(0, Scroll.Child.Children.Count);
                 Scheduler.AddDelayed(() => Scroll.Child.Children[idx].State.Value = CarouselItemState.Selected, 50);
@@ -111,10 +114,10 @@ namespace Circle.Game.Screens.Select
 
             foreach (var item in Scroll.Child.Children)
             {
-                if (item.BeatmapInfo.Settings.Track == working.Value.Settings.Track)
+                if (item.BeatmapInfo == working.Value)
                 {
                     item.State.Value = CarouselItemState.Selected;
-                    return;
+                    break;
                 }
             }
         }
@@ -160,9 +163,9 @@ namespace Circle.Game.Screens.Select
             }
         }
 
-        protected class CarouselScrollContiner : CircleScrollContainer<FillFlowContainer<CarouselItem>>
+        protected class CarouselScrollContainer : CircleScrollContainer<FillFlowContainer<CarouselItem>>
         {
-            public CarouselScrollContiner()
+            public CarouselScrollContainer()
             {
                 ScrollContent.AutoSizeAxes = Axes.None;
                 Masking = false;

--- a/Circle.Game/Screens/Select/BeatmapCarousel.cs
+++ b/Circle.Game/Screens/Select/BeatmapCarousel.cs
@@ -81,7 +81,7 @@ namespace Circle.Game.Screens.Select
 
                         Schedule(() =>
                         {
-                            if (working.Value.Equals(item.BeatmapInfo))
+                            if (!working.Value.Equals(item.BeatmapInfo))
                             {
                                 working.Value = item.BeatmapInfo;
                                 music.Play();

--- a/Circle.Game/Screens/Select/Carousel/CarouselItem.cs
+++ b/Circle.Game/Screens/Select/Carousel/CarouselItem.cs
@@ -131,7 +131,6 @@ namespace Circle.Game.Screens.Select.Carousel
             switch (state.NewValue)
             {
                 case CarouselItemState.NotSelected:
-                case CarouselItemState.Collapsed:
                     BorderContainer.BorderThickness = 0;
                     BorderContainer.EdgeEffect = new EdgeEffectParameters
                     {

--- a/Circle.Game/Screens/Select/Carousel/CarouselItemState.cs
+++ b/Circle.Game/Screens/Select/Carousel/CarouselItemState.cs
@@ -2,7 +2,6 @@
 {
     public enum CarouselItemState
     {
-        Collapsed,
         NotSelected,
         Selected,
         PlayRequested


### PR DESCRIPTION
Closing #30 

현재 트랙과 비교하여 생긴 문제를 구조체를 비교하는 방법으로 문제를 해결합니다.

## 변경 사항
+ 잘못된 스펠링 수정
+ 사용하지 않는 `CarouselItemState.Collapsed` 제거
+ Adofai 파일과 비슷하게 `Event`멤버 수정
+ BPM 승수 추가
+ 카메라 기준 좌표 추가
+ ~~`BeatmapInfo`와 `Settings`에 연산자 추가~~
+ `Background.FadeTextureTo()`에서 컴포넌트 로드를 동기적으로 변경
+ `Background`에 대한 테스트 케이스 추가