### PR TITLE
Add tile fading in/out

### DIFF
--- a/Circle.Game/Screens/Play/Playfield.cs
+++ b/Circle.Game/Screens/Play/Playfield.cs
@@ -57,6 +57,11 @@ namespace Circle.Game.Screens.Play
             bluePlanet.Rotation = tiles.Children[0].Angle - 180;
             planetState.ValueChanged += _ => movePlanet();
             planetState.ValueChanged += _ => this.MoveTo(-tiles.Children[currentFloor].Position, 500, Easing.OutSine);
+
+            for (int i = 9; i < tiles.Children.Count; i++)
+            {
+                tiles.Children[i].Alpha = 0;
+            }
         }
 
         public void StartPlaying()
@@ -141,6 +146,14 @@ namespace Circle.Game.Screens.Play
 
             currentFloor++;
 
+            if (currentFloor + 8 < tiles.Children.Count)
+                tiles.Children[currentFloor + 8].FadeTo(0.6f, 60000 / currentBpm, Easing.Out);
+            else
+                tiles.Children[currentFloor].FadeTo(0.6f, 60000 / currentBpm, Easing.Out);
+
+            if (currentFloor > 3)
+                tiles.Children[currentFloor - 4].FadeOut(60000 / currentBpm, Easing.Out);
+
             if (planetState.Value == PlanetState.Fire)
             {
                 redPlanet.Expansion = 0;
@@ -161,6 +174,15 @@ namespace Circle.Game.Screens.Play
             else
             {
                 currentFloor++;
+
+                if (currentFloor + 8 < tiles.Children.Count)
+                    tiles.Children[currentFloor + 8].FadeTo(0.6f, 60000 / currentBpm, Easing.Out);
+                else
+                    tiles.Children[currentFloor].FadeTo(0.6f, 60000 / currentBpm, Easing.Out);
+
+                if (currentFloor > 3)
+                    tiles.Children[currentFloor - 4].FadeOut(60000 / currentBpm, Easing.Out);
+
                 movePlanet();
             }
         }


### PR DESCRIPTION
8박자 뒤에 있는 타일을 페이드 인, 4박자 뒤에있는 타일은 페이드 아웃 합니다.

타일 페이드 인/아웃으로 성능이 증가했습니다.

# 성능 비교
**측정 환경:**
* CPU: AMD Ryzen 7 5700G
* RAM: DDR4 16GB
* GPU: NVIDIA GeForce GTX 1070

**설정:**
* Screen mode: Windowed
* Frame limiter: Unlimited
* Threading mode: MultiThreaded
* Frame overlay: On

프레임 오버레이에서 draw 지연시간(ms)으로 측정하여 비교했습니다.
## [Appeal] かめりあ (Camellia) - We Could Get More Machinegun Psystyle! (And More Genre Switches):
### `2022.107.0`: 평균 0.9ms → `this branch`: 평균 0.5ms, *57%* 감소

## [NumbEr07] Cansol - Once Again:
### `2022.107.0`: 평균 0.75ms → `this branch`: 평균 0.45ms, *50%* 감소

## [RedCRP] Plum - Maelstrom:
### `2022.107.0`: 평균 0.8ms → `this branch`: 평균 0.5ms, *46%* 감소

평균 **51%** 감소.


