### PR TITLE
Add setting to load beatmap at app startup

### DIFF
--- a/Circle.Game.Tests/CircleTestBrowser.cs
+++ b/Circle.Game.Tests/CircleTestBrowser.cs
@@ -1,3 +1,4 @@
+using Circle.Game.Configuration;
 using Circle.Game.Graphics.UserInterface;
 using Circle.Game.Overlays;
 using osu.Framework.Allocation;
@@ -15,6 +16,13 @@ namespace Circle.Game.Tests
 
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent) =>
             dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
+
+        [BackgroundDependencyLoader]
+        private void load(CircleConfigManager config)
+        {
+            if (config.Get<bool>(CircleSetting.LoadBeatmapsOnStartup))
+                BeatmapManager.ReloadBeatmaps();
+        }
 
         protected override void LoadComplete()
         {

--- a/Circle.Game.Tests/Visual/Overlays/TestSceneMusicController.cs
+++ b/Circle.Game.Tests/Visual/Overlays/TestSceneMusicController.cs
@@ -26,9 +26,9 @@ namespace Circle.Game.Tests.Visual.Overlays
         }
 
         [BackgroundDependencyLoader]
-        private void load(BeatmapStorage beatmaps, MusicController music)
+        private void load(BeatmapManager beatmaps, MusicController music)
         {
-            foreach (var beatmap in beatmaps.GetBeatmaps())
+            foreach (var beatmap in beatmaps.LoadedBeatmaps)
             {
                 AddStep($"{beatmap.Settings.SongFileName}", () => music.ChangeTrack(beatmap));
             }

--- a/Circle.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/Circle.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -10,7 +10,7 @@ namespace Circle.Game.Tests.Visual.SongSelect
     public class TestSceneBeatmapCarousel : CircleTestScene
     {
         [BackgroundDependencyLoader]
-        private void load(BeatmapStorage beatmaps)
+        private void load(BeatmapManager beatmaps)
         {
             BeatmapCarousel carousel;
 
@@ -25,7 +25,7 @@ namespace Circle.Game.Tests.Visual.SongSelect
             AddRepeatStep("Select beatmap(down)", () => carousel.SelectBeatmap(VerticalDirection.Down), 5);
             AddRepeatStep("Select beatmap(up)", () => carousel.SelectBeatmap(VerticalDirection.Up), 5);
             AddLabel("Select beatmap(beatmap)");
-            foreach (var beatmap in beatmaps.GetBeatmaps())
+            foreach (var beatmap in beatmaps.LoadedBeatmaps)
                 AddStep($"Select beatmap({beatmap.Settings.Song})", () => carousel.SelectBeatmap(beatmap));
         }
     }

--- a/Circle.Game.Tests/Visual/SongSelect/TestSceneBeatmapDetails.cs
+++ b/Circle.Game.Tests/Visual/SongSelect/TestSceneBeatmapDetails.cs
@@ -8,13 +8,13 @@ namespace Circle.Game.Tests.Visual.SongSelect
     public class TestSceneBeatmapDetails : CircleTestScene
     {
         [BackgroundDependencyLoader]
-        private void load(BeatmapStorage beatmaps)
+        private void load(BeatmapManager beatmaps)
         {
             BeatmapDetails details;
 
             Add(details = new BeatmapDetails { Padding = new MarginPadding(10) });
             AddLabel("Beatmaps");
-            foreach (var beatmap in beatmaps.GetBeatmaps())
+            foreach (var beatmap in beatmaps.LoadedBeatmaps)
                 AddStep($"Change to {beatmap.Settings.SongFileName}", () => details.ChangeBeatmap(beatmap));
         }
     }

--- a/Circle.Game/Beatmap/BeatmapManager.cs
+++ b/Circle.Game/Beatmap/BeatmapManager.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Logging;
+
+namespace Circle.Game.Beatmap
+{
+    public class BeatmapManager
+    {
+        private readonly BeatmapStorage beatmapStorage;
+
+        private BeatmapInfo currentBeatmap;
+
+        public BeatmapInfo CurrentBeatmap
+        {
+            get => currentBeatmap;
+            set
+            {
+                OnBeatmapChanged?.Invoke((currentBeatmap, value));
+                currentBeatmap = value;
+            }
+        }
+
+        private List<BeatmapInfo> loadedBeatmaps;
+
+        public IList<BeatmapInfo> LoadedBeatmaps => loadedBeatmaps;
+
+        public event Action<(BeatmapInfo oldBeatmap, BeatmapInfo newBeatmap)> OnBeatmapChanged;
+
+        public event Action<IList<BeatmapInfo>> OnLoadedBeatmaps;
+
+        public BeatmapManager(BeatmapStorage beatmaps)
+        {
+            beatmapStorage = beatmaps;
+            OnBeatmapChanged += beatmap =>
+            {
+                var oldBeatmapName = $"[{beatmap.oldBeatmap.Settings.Author}] {beatmap.oldBeatmap.Settings.Artist} - {beatmap.oldBeatmap.Settings.Song}";
+                var newBeatmapName = $"[{beatmap.newBeatmap.Settings.Author}] {beatmap.newBeatmap.Settings.Artist} - {beatmap.newBeatmap.Settings.Song}";
+                Logger.Log($"Beatmap changed: {oldBeatmapName} → {newBeatmapName}.");
+            };
+        }
+
+        /// <summary>
+        /// 폴더에 존재하는 비트맵을 로드합니다.
+        /// </summary>
+        public void ReloadBeatmaps()
+        {
+            loadedBeatmaps = beatmapStorage.GetBeatmaps().ToList();
+            OnLoadedBeatmaps?.Invoke(loadedBeatmaps);
+            if (!loadedBeatmaps.Exists(b => b.Equals(currentBeatmap)))
+                ClearCurrentBeatmap();
+        }
+
+        /// <summary>
+        /// 현재 비트맵을 비웁니다.
+        /// </summary>
+        public void ClearCurrentBeatmap()
+        {
+            var oldBeatmap = CurrentBeatmap;
+            CurrentBeatmap = new BeatmapInfo();
+            OnBeatmapChanged?.Invoke((oldBeatmap, CurrentBeatmap));
+        }
+
+        /// <summary>
+        /// 비트맵을 파일로 저장합니다.
+        /// </summary>
+        /// <param name="beatmap">저장할 비트맵.</param>
+        public void SaveBeatmap(BeatmapInfo beatmap) => beatmapStorage.CreateBeatmap(beatmap);
+
+        /// <summary>
+        /// 비트맵 파일을 삭제합니다. 삭제할 비트맵이 현재 비트맵일 때 현재 비트맵을 비웁니다.
+        /// </summary>
+        /// <param name="beatmap">삭제할 비트맵.</param>
+        /// <param name="deleteResources">비트맵에 사용된 리소스 삭제 여부.</param>
+        /// <returns></returns>
+        public bool DeleteBeatmap(BeatmapInfo beatmap, bool deleteResources)
+        {
+            beatmapStorage.DeleteBeatmap(beatmap, deleteResources);
+
+            if (beatmap.Equals(currentBeatmap))
+                ClearCurrentBeatmap();
+
+            return LoadedBeatmaps.Remove(beatmap);
+        }
+    }
+}

--- a/Circle.Game/Beatmap/BeatmapResourcesManager.cs
+++ b/Circle.Game/Beatmap/BeatmapResourcesManager.cs
@@ -13,13 +13,17 @@ namespace Circle.Game.Beatmap
     {
         private readonly LargeTextureStore largeTextureStore;
         private readonly ITrackStore trackStore;
-        private readonly Storage files;
+
+        public readonly Storage Backgrounds;
+        public readonly Storage Tracks;
 
         public BeatmapResourcesManager(Storage storage, AudioManager audioManager, GameHost host = null)
         {
-            trackStore = audioManager.GetTrackStore(new StorageBackedResourceStore(storage.GetStorageForDirectory("tracks")));
-            files = storage;
-            largeTextureStore = new LargeTextureStore(host?.CreateTextureLoaderStore(new StorageBackedResourceStore(storage.GetStorageForDirectory("backgrounds"))));
+            var files = storage;
+            Backgrounds = files.GetStorageForDirectory("backgrounds");
+            Tracks = files.GetStorageForDirectory("tracks");
+            largeTextureStore = new LargeTextureStore(host?.CreateTextureLoaderStore(new StorageBackedResourceStore(Backgrounds)));
+            trackStore = audioManager.GetTrackStore(new StorageBackedResourceStore(Tracks));
         }
 
         public Texture GetBackground(BeatmapInfo info)
@@ -27,11 +31,9 @@ namespace Circle.Game.Beatmap
             if (string.IsNullOrEmpty(info.Settings.BgImage))
                 return null;
 
-            var backgrounds = files.GetStorageForDirectory("backgrounds");
-
             try
             {
-                return largeTextureStore.Get(Path.Combine(backgrounds.GetFullPath(string.Empty), $"{info.Settings.BgImage}"));
+                return largeTextureStore.Get(Path.Combine(Backgrounds.GetFullPath(string.Empty), $"{info.Settings.BgImage}"));
             }
             catch (Exception e)
             {
@@ -45,11 +47,9 @@ namespace Circle.Game.Beatmap
             if (string.IsNullOrEmpty(name))
                 return null;
 
-            var backgrounds = files.GetStorageForDirectory("backgrounds");
-
             try
             {
-                return largeTextureStore.Get(Path.Combine(backgrounds.GetFullPath(string.Empty), $"{name}"));
+                return largeTextureStore.Get(Path.Combine(Backgrounds.GetFullPath(string.Empty), $"{name}"));
             }
             catch (Exception e)
             {
@@ -63,11 +63,9 @@ namespace Circle.Game.Beatmap
             if (string.IsNullOrEmpty(info.Settings.SongFileName))
                 return null;
 
-            var tracks = files.GetStorageForDirectory("tracks");
-
             try
             {
-                return trackStore.Get(Path.Combine(tracks.GetFullPath(string.Empty), $"{info.Settings.SongFileName}"));
+                return trackStore.Get(Path.Combine(Tracks.GetFullPath(string.Empty), $"{info.Settings.SongFileName}"));
             }
             catch
             {
@@ -81,11 +79,9 @@ namespace Circle.Game.Beatmap
             if (string.IsNullOrEmpty(name))
                 return null;
 
-            var tracks = files.GetStorageForDirectory("tracks");
-
             try
             {
-                return trackStore.Get(Path.Combine(tracks.GetFullPath(string.Empty), $"{name}"));
+                return trackStore.Get(Path.Combine(Tracks.GetFullPath(string.Empty), $"{name}"));
             }
             catch
             {

--- a/Circle.Game/Beatmap/BeatmapStorage.cs
+++ b/Circle.Game/Beatmap/BeatmapStorage.cs
@@ -8,20 +8,26 @@ namespace Circle.Game.Beatmap
 {
     public class BeatmapStorage
     {
-        private readonly Storage storage;
+        private readonly Storage beatmapStorage;
+        private readonly BeatmapResourcesManager resources;
 
-        public BeatmapStorage(Storage storage)
+        public BeatmapStorage(Storage files, BeatmapResourcesManager resourcesManager)
         {
-            this.storage = storage?.GetStorageForDirectory("beatmaps");
+            beatmapStorage = files?.GetStorageForDirectory("beatmaps");
+            resources = resourcesManager;
         }
 
+        /// <summary>
+        /// 폴더에 존재하는 비트맵의 집합을 반환합니다.
+        /// </summary>
+        /// <returns>폴더에 존재하는 비트맵의 집합.</returns>
         public IReadOnlyList<BeatmapInfo> GetBeatmaps()
         {
             List<BeatmapInfo> beatmaps = new List<BeatmapInfo>();
 
-            foreach (var file in storage.GetFiles(string.Empty))
+            foreach (var file in beatmapStorage.GetFiles(string.Empty))
             {
-                StreamReader sr = File.OpenText(storage.GetFullPath(string.Empty) + $"/{file}");
+                StreamReader sr = File.OpenText(Path.Combine(beatmapStorage.GetFullPath(string.Empty), $"{file}"));
                 var text = sr.ReadLine();
                 sr.Close();
 
@@ -40,15 +46,33 @@ namespace Circle.Game.Beatmap
             return beatmaps;
         }
 
-        public void CreateBeatmap(BeatmapInfo info)
+        /// <summary>
+        /// 비트맵을 파일로 저장합니다.
+        /// </summary>
+        /// <param name="beatmap">저장할 비트맵.</param>
+        public void CreateBeatmap(BeatmapInfo beatmap)
         {
-            string json = JsonConvert.SerializeObject(info);
+            string json = JsonConvert.SerializeObject(beatmap);
 
-            StreamWriter sw = File.CreateText(storage.GetFullPath(string.Empty) + $"/[{info.Settings.Author}] {info.Settings.Artist} - {info.Settings.Song}.circle");
+            StreamWriter sw = File.CreateText(Path.Combine(beatmapStorage.GetFullPath(string.Empty), $"[{beatmap.Settings.Author}] {beatmap.Settings.Artist} - {beatmap.Settings.Song}.circle"));
             sw.WriteLine(json);
             sw.Close();
         }
 
-        public void DeleteBeatmap(string name) => Directory.Delete(storage.GetFullPath(string.Empty) + $"/{name}.circle");
+        /// <summary>
+        /// 비트맵 파일을 삭제합니다.
+        /// </summary>
+        /// <param name="beatmap">삭제할 비트맵.</param>
+        /// <param name="deleteResources">비트맵에 사용된 리소스 삭제 여부.</param>
+        public void DeleteBeatmap(BeatmapInfo beatmap, bool deleteResources)
+        {
+            File.Delete(Path.Combine(beatmapStorage.GetFullPath(string.Empty), $"[{beatmap.Settings.Author}] {beatmap.Settings.Artist} - {beatmap.Settings.Song}.circle"));
+
+            if (deleteResources)
+            {
+                File.Delete(Path.Combine(resources.Backgrounds.GetFullPath(string.Empty), beatmap.Settings.BgImage));
+                File.Delete(Path.Combine(resources.Backgrounds.GetFullPath(string.Empty), beatmap.Settings.SongFileName));
+            }
+        }
     }
 }

--- a/Circle.Game/Configuration/CircleConfigManager.cs
+++ b/Circle.Game/Configuration/CircleConfigManager.cs
@@ -19,6 +19,7 @@ namespace Circle.Game.Configuration
             SetDefault(CircleSetting.Scale, 1f, 0.8f, 1.6f);
             SetDefault(CircleSetting.FpsDisplay, false);
             SetDefault(CircleSetting.Offset, 0);
+            SetDefault(CircleSetting.LoadBeatmapsOnStartup, true);
         }
 
         public override TrackedSettings CreateTrackedSettings()
@@ -43,6 +44,12 @@ namespace Circle.Game.Configuration
                         value: $"{offset}"
                     )
                 ),
+                new TrackedSetting<bool>(CircleSetting.LoadBeatmapsOnStartup, loadBeatmap => new SettingDescription(
+                        rawValue: loadBeatmap,
+                        name: "LoadBeatmapsOnStartup",
+                        value: $"{loadBeatmap}"
+                    )
+                )
             };
         }
     }
@@ -52,5 +59,6 @@ namespace Circle.Game.Configuration
         Scale,
         FpsDisplay,
         Offset,
+        LoadBeatmapsOnStartup
     }
 }

--- a/Circle.Game/Screens/MainScreen.cs
+++ b/Circle.Game/Screens/MainScreen.cs
@@ -1,4 +1,6 @@
 using System;
+using Circle.Game.Beatmap;
+using Circle.Game.Configuration;
 using Circle.Game.Graphics.UserInterface;
 using Circle.Game.Input;
 using Circle.Game.Overlays;
@@ -39,7 +41,7 @@ namespace Circle.Game.Screens
         private IconWithTextButton exit;
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(CircleConfigManager localConfig, BeatmapManager beatmapManager)
         {
             InternalChildren = new Drawable[]
             {
@@ -84,6 +86,9 @@ namespace Circle.Game.Screens
                     }
                 }
             };
+
+            if (localConfig.Get<bool>(CircleSetting.LoadBeatmapsOnStartup))
+                beatmapManager.ReloadBeatmaps();
         }
 
         public override void OnResuming(IScreen last)

--- a/Circle.Game/Screens/Play/MasterGameplayClockContainer.cs
+++ b/Circle.Game/Screens/Play/MasterGameplayClockContainer.cs
@@ -1,7 +1,6 @@
 ﻿using Circle.Game.Beatmap;
 using Circle.Game.Rulesets.UI;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Timing;
 
@@ -9,13 +8,13 @@ namespace Circle.Game.Screens.Play
 {
     public class MasterGameplayClockContainer : GameplayClockContainer
     {
-        private readonly Bindable<BeatmapInfo> beatmap;
+        private readonly BeatmapInfo beatmap;
 
         public Playfield Playfield;
 
         private bool isStarted;
 
-        public MasterGameplayClockContainer(Bindable<BeatmapInfo> beatmap, IClock clock)
+        public MasterGameplayClockContainer(BeatmapInfo beatmap, IClock clock)
             : base(clock)
         {
             this.beatmap = beatmap;
@@ -26,14 +25,14 @@ namespace Circle.Game.Screens.Play
         {
             Children = new Drawable[]
             {
-                new FrameStabilityContainer(beatmap.Value.Settings.Offset)
+                new FrameStabilityContainer(beatmap.Settings.Offset)
                 {
                     Child = Playfield = new Playfield(),
                 }
             };
 
             // 음악 시작 시간보다 한 박자 먼저 시작됩니다.
-            Seek(beatmap.Value.Settings.Offset - 60000 / beatmap.Value.Settings.Bpm);
+            Seek(beatmap.Settings.Offset - 60000 / beatmap.Settings.Bpm);
         }
 
         public override void Start()

--- a/Circle.Game/Screens/Play/ObjectContainer.cs
+++ b/Circle.Game/Screens/Play/ObjectContainer.cs
@@ -5,7 +5,6 @@ using Circle.Game.Beatmap;
 using Circle.Game.Rulesets.Extensions;
 using Circle.Game.Rulesets.Objects;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osuTK;
@@ -26,9 +25,9 @@ namespace Circle.Game.Screens.Play
         }
 
         [BackgroundDependencyLoader]
-        private void load(Bindable<BeatmapInfo> beatmap)
+        private void load(BeatmapManager beatmap)
         {
-            beatmapInfo = beatmap.Value;
+            beatmapInfo = beatmap.CurrentBeatmap;
             createTiles();
         }
 

--- a/Circle.Game/Screens/Play/Player.cs
+++ b/Circle.Game/Screens/Play/Player.cs
@@ -6,7 +6,6 @@ using Circle.Game.Overlays;
 using Circle.Game.Screens.Setting;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
-using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -51,7 +50,7 @@ namespace Circle.Game.Screens.Play
         private MusicController musicController { get; set; }
 
         [Resolved]
-        private Bindable<BeatmapInfo> beatmap { get; set; }
+        private BeatmapManager beatmap { get; set; }
 
         [Resolved]
         private DialogOverlay dialog { get; set; }
@@ -65,7 +64,7 @@ namespace Circle.Game.Screens.Play
         {
             InternalChildren = new Drawable[]
             {
-                masterGameplayClockContainer = new MasterGameplayClockContainer(beatmap, Clock),
+                masterGameplayClockContainer = new MasterGameplayClockContainer(beatmap.CurrentBeatmap, Clock),
                 new Container
                 {
                     AutoSizeAxes = Axes.Both,
@@ -76,7 +75,7 @@ namespace Circle.Game.Screens.Play
                     {
                         new SpriteText
                         {
-                            Text = $"{beatmap.Value.Settings.Artist} - {beatmap.Value.Settings.Song}",
+                            Text = $"{beatmap.CurrentBeatmap.Settings.Artist} - {beatmap.CurrentBeatmap.Settings.Song}",
                             Font = FontUsage.Default.With(family: "OpenSans-Bold", size: 32),
                             Shadow = true,
                             ShadowColour = Color4.Black.Opacity(0.4f),
@@ -97,8 +96,8 @@ namespace Circle.Game.Screens.Play
                            .Schedule(() =>
                            {
                                musicController.Stop();
-                               musicController.ChangeTrack(beatmap.Value);
-                               musicController.SeekTo(beatmap.Value.Settings.Offset);
+                               musicController.ChangeTrack(beatmap.CurrentBeatmap);
+                               musicController.SeekTo(beatmap.CurrentBeatmap.Settings.Offset);
                                playState = GamePlayState.Ready;
                            });
         }
@@ -113,7 +112,7 @@ namespace Circle.Game.Screens.Play
                 case GamePlayState.Ready:
                     masterGameplayClockContainer.Start();
                     musicController.CurrentTrack.VolumeTo(1);
-                    Scheduler.AddDelayed(() => musicController.Play(), 60000 / beatmap.Value.Settings.Bpm);
+                    Scheduler.AddDelayed(() => musicController.Play(), 60000 / beatmap.CurrentBeatmap.Settings.Bpm);
                     playState = GamePlayState.Playing;
                     break;
 

--- a/Circle.Game/Screens/Play/Playfield.cs
+++ b/Circle.Game/Screens/Play/Playfield.cs
@@ -4,7 +4,6 @@ using Circle.Game.Beatmap;
 using Circle.Game.Rulesets.Extensions;
 using Circle.Game.Rulesets.Objects;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osuTK.Graphics;
@@ -19,7 +18,7 @@ namespace Circle.Game.Screens.Play
         private Container<Planet> planetContainer;
 
         [Resolved]
-        private Bindable<BeatmapInfo> beatmap { get; set; }
+        private BeatmapManager beatmap { get; set; }
 
         private TileInfo[] tileInfos;
 
@@ -59,8 +58,8 @@ namespace Circle.Game.Screens.Play
 
         protected override void LoadComplete()
         {
-            addTileTransforms(beatmap.Value.Settings.Offset - 60000 / beatmap.Value.Settings.Bpm);
-            addTransforms(beatmap.Value.Settings.Offset - 60000 / beatmap.Value.Settings.Bpm);
+            addTileTransforms(beatmap.CurrentBeatmap.Settings.Offset - 60000 / beatmap.CurrentBeatmap.Settings.Bpm);
+            addTransforms(beatmap.CurrentBeatmap.Settings.Offset - 60000 / beatmap.CurrentBeatmap.Settings.Bpm);
 
             base.LoadComplete();
         }
@@ -70,7 +69,7 @@ namespace Circle.Game.Screens.Play
             double startTimeOffset = gameplayStartTime;
             PlanetState planetState = PlanetState.Ice;
             float previousAngle;
-            float bpm = beatmap.Value.Settings.Bpm;
+            float bpm = beatmap.CurrentBeatmap.Settings.Bpm;
             int floor = 0;
             Easing easing = Easing.None;
 
@@ -194,7 +193,7 @@ namespace Circle.Game.Screens.Play
         private void addTileTransforms(double gameplayStartTime)
         {
             double startTimeOffset = gameplayStartTime;
-            float bpm = beatmap.Value.Settings.Bpm;
+            float bpm = beatmap.CurrentBeatmap.Settings.Bpm;
             float previousAngle = CalculationExtensions.GetSafeAngle(tileInfos.First().Angle - 180);
 
             for (int i = 8; i < tileInfos.Length; i++)
@@ -215,7 +214,7 @@ namespace Circle.Game.Screens.Play
             }
 
             startTimeOffset = gameplayStartTime;
-            bpm = beatmap.Value.Settings.Bpm;
+            bpm = beatmap.CurrentBeatmap.Settings.Bpm;
             previousAngle = CalculationExtensions.GetSafeAngle(tileInfos.First().Angle - 180);
             isClockwise = true;
 

--- a/Circle.Game/Screens/Select/BeatmapDetails.cs
+++ b/Circle.Game/Screens/Select/BeatmapDetails.cs
@@ -2,7 +2,6 @@
 using Circle.Game.Graphics.Containers;
 using Circle.Game.Graphics.UserInterface;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
@@ -18,18 +17,19 @@ namespace Circle.Game.Screens.Select
     public class BeatmapDetails : Container
     {
         [Resolved]
-        private Bindable<BeatmapInfo> workingBeatmap { get; set; }
+        private BeatmapManager beatmapManager { get; set; }
 
-        private readonly Background background;
-        private readonly SpriteText title;
-        private readonly SpriteText artist;
+        private Background background;
+        private SpriteText title;
+        private SpriteText artist;
 
-        private readonly SpriteText author;
-        private readonly SpriteText bpm;
-        private readonly SpriteText difficulty;
-        private readonly TextFlowContainer description;
+        private SpriteText author;
+        private SpriteText bpm;
+        private SpriteText difficulty;
+        private TextFlowContainer description;
 
-        public BeatmapDetails()
+        [BackgroundDependencyLoader]
+        private void load()
         {
             RelativeSizeAxes = Axes.Both;
             Child = new Container
@@ -179,30 +179,30 @@ namespace Circle.Game.Screens.Select
         {
             base.LoadComplete();
 
-            workingBeatmap.BindValueChanged(onBeatmapChanged);
-            workingBeatmap.TriggerChange();
+            // 로드 후 한번만 동기화 해야합니다.
+            ChangeBeatmap(beatmapManager.CurrentBeatmap);
         }
 
-        public void ChangeBeatmap(BeatmapInfo beatmap) => workingBeatmap.Value = beatmap;
+        public void ChangeBeatmap(BeatmapInfo beatmap) => onBeatmapChanged(beatmap);
 
-        private void onBeatmapChanged(ValueChangedEvent<BeatmapInfo> beatmap)
+        private void onBeatmapChanged(BeatmapInfo newBeatmap)
         {
-            if (string.IsNullOrEmpty(beatmap.NewValue.Settings.BgImage))
+            if (string.IsNullOrEmpty(newBeatmap.Settings.BgImage))
                 background.ChangeTexture(TextureSource.Internal, "bg1", 500, Easing.Out);
             else
-                background.ChangeTexture(TextureSource.External, beatmap.NewValue.Settings.BgImage, 500, Easing.Out);
+                background.ChangeTexture(TextureSource.External, newBeatmap.Settings.BgImage, 500, Easing.Out);
 
-            if (!string.IsNullOrEmpty(beatmap.NewValue.Settings.Song) && !string.IsNullOrEmpty(beatmap.NewValue.Settings.Artist))
+            if (!string.IsNullOrEmpty(newBeatmap.Settings.Song) && !string.IsNullOrEmpty(newBeatmap.Settings.Artist))
             {
-                title.Text = beatmap.NewValue.Settings.Song;
-                artist.Text = beatmap.NewValue.Settings.Artist;
+                title.Text = newBeatmap.Settings.Song;
+                artist.Text = newBeatmap.Settings.Artist;
             }
 
-            author.Text = $"Author: {beatmap.NewValue.Settings.Author}";
-            bpm.Text = $"BPM: {beatmap.NewValue.Settings.Bpm}";
-            difficulty.Text = $"Difficulty: {beatmap.NewValue.Settings.Difficulty}";
+            author.Text = $"Author: {newBeatmap.Settings.Author}";
+            bpm.Text = $"BPM: {newBeatmap.Settings.Bpm}";
+            difficulty.Text = $"Difficulty: {newBeatmap.Settings.Difficulty}";
             description.Clear();
-            description.AddText($"Description: {beatmap.NewValue.Settings.BeatmapDesc}", t => t.Font = FontUsage.Default.With(size: 24));
+            description.AddText($"Description: {newBeatmap.Settings.BeatmapDesc}", t => t.Font = FontUsage.Default.With(size: 24));
         }
     }
 }

--- a/Circle.Game/Screens/Select/SongSelectScreen.cs
+++ b/Circle.Game/Screens/Select/SongSelectScreen.cs
@@ -44,6 +44,7 @@ namespace Circle.Game.Screens.Select
                 if (v.NewValue)
                     this.Push(new Player());
             };
+            carousel.SelectedBeatmap.ValueChanged += beatmap => details.ChangeBeatmap(beatmap.NewValue);
         }
 
         public override bool OnPressed(KeyBindingPressEvent<InputAction> e)

--- a/Circle.Game/Screens/Setting/Sections/DebugSection.cs
+++ b/Circle.Game/Screens/Setting/Sections/DebugSection.cs
@@ -1,4 +1,5 @@
-﻿using Circle.Game.Configuration;
+﻿using Circle.Game.Beatmap;
+using Circle.Game.Configuration;
 using Circle.Game.Graphics.UserInterface;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -12,10 +13,27 @@ namespace Circle.Game.Screens.Setting.Sections
         public override string Header => "Debug";
 
         [BackgroundDependencyLoader]
-        private void load(CircleGameBase gameBase, GameHost host, CircleConfigManager config)
+        private void load(CircleGameBase gameBase, GameHost host, CircleConfigManager config, BeatmapManager beatmap)
         {
             FlowContent.AddRange(new Drawable[]
             {
+                new Stepper<bool>
+                {
+                    Text = "Load beatmaps on startup",
+                    Current = config.GetBindable<bool>(CircleSetting.LoadBeatmapsOnStartup),
+                    Item = new[]
+                    {
+                        new StepperItem<bool>(CircleSetting.LoadBeatmapsOnStartup, true, "On"),
+                        new StepperItem<bool>(CircleSetting.LoadBeatmapsOnStartup, false, "Off")
+                    }
+                },
+                new BoxButton
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Text = "Reload beatmaps",
+                    Action = beatmap.ReloadBeatmaps
+                },
                 new BoxButton
                 {
                     Anchor = Anchor.Centre,


### PR DESCRIPTION
# 주요 변경 사항

## 비트맵과 관련된 모든 작업은 `BeatmapManager`에서 합니다.
비트맵 저장/삭제, 현재 비트맵 비우기, 비트맵 로드를 사용할 수 있으며,
비트맵 로드완료 이벤트는 `OnLoadedBeatmaps`, 현재 비트맵 변경 이벤트는 `OnBeatmapChanged`로 다양한 처리가 가능합니다.

## 비트맵 로드 설정이 추가되었습니다.
이전에는 `SongSelectScreen`을 진입할 때마다 비트맵을 로드해 진입할 때까지의 시간이 오래 걸리고 자원소모가 심했습니다.
이제 비트맵들을 한번 로드하면 메모리에 저장됩니다.
비트맵 폴더/파일에 변경사항이 있을때 설정에서 비트맵들을 다시 로드할 수 있습니다.
이러한 변경점으로 앱이 시작되었을 때(정확히 `MainScreen`에 진입할 때) 비트맵들을 로드 여부를 설정할 수 있습니다.

## 발생한 문제
`OnBeatmapChanged`로 `BeatmapDetails`의 정보를 업데이트 할 때 TextFlowContainer에서 `ObjectDisposedException`이 발생하여 임시로 `BeatmapCarousel.SelectedBeatmap`으로 작동하게 했습니다. 이벤트 제거가 되지않아 폐기된 개체에 접근하는 것으로 보여집니다. 디버깅 차원에서 원인을 찾지 못해 더 자세한 조사가 필요합니다.