### PR TITLE
Move calculation methods in `Planet` and `Tile` to `CalculationExtensions`

### DIFF
--- a/Circle.Game.Tests/Visual/Play/TestSceneGameProgressBar.cs
+++ b/Circle.Game.Tests/Visual/Play/TestSceneGameProgressBar.cs
@@ -1,0 +1,23 @@
+﻿using Circle.Game.Screens.Play;
+using osu.Framework.Graphics;
+using osuTK;
+using osuTK.Graphics;
+
+namespace Circle.Game.Tests.Visual.Play
+{
+    public class TestSceneGameProgressBar : CircleTestScene
+    {
+        public TestSceneGameProgressBar()
+        {
+            GameProgressBar bar;
+            Add(bar = new GameProgressBar(20, 5)
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                StartFloor = 0,
+                EndFloor = 20
+            });
+            AddSliderStep("Progress", 0, 20, 5, v => bar.CurrentFloor = v);
+        }
+    }
+}

--- a/Circle.Game.Tests/Visual/Play/TestSceneGameProgressBar.cs
+++ b/Circle.Game.Tests/Visual/Play/TestSceneGameProgressBar.cs
@@ -1,7 +1,5 @@
 ﻿using Circle.Game.Screens.Play;
 using osu.Framework.Graphics;
-using osuTK;
-using osuTK.Graphics;
 
 namespace Circle.Game.Tests.Visual.Play
 {

--- a/Circle.Game/Rulesets/Extensions/CalculationExtensions.cs
+++ b/Circle.Game/Rulesets/Extensions/CalculationExtensions.cs
@@ -57,13 +57,13 @@ namespace Circle.Game.Rulesets.Extensions
             var tilesInfo = GetTilesInfo(beatmap).ToArray();
             double startTimeOffset = gameplayStartTime;
             float bpm = beatmap.Settings.Bpm;
-
-            // 한 박자 앞에서 시작합니다.
-            float prevAngle = tilesInfo[0].Angle - 180;
-            startTimeOffset += GetRelativeDuration(prevAngle, tilesInfo[0].Angle, bpm);
+            float prevAngle = tilesInfo[0].Angle;
             List<double> hitStartTimes = new List<double> { startTimeOffset };
 
-            for (int floor = 1; floor < tilesInfo.Length; floor++)
+            startTimeOffset += GetRelativeDuration(tilesInfo[0].Angle - 180, tilesInfo[0].Angle, bpm);
+            hitStartTimes.Add(startTimeOffset);
+
+            for (int floor = 1; floor < tilesInfo.Length - 1; floor++)
             {
                 var (fixedRotation, newRotation) = ComputeRotation(tilesInfo, floor, prevAngle);
 

--- a/Circle.Game/Rulesets/Extensions/CalculationExtensions.cs
+++ b/Circle.Game/Rulesets/Extensions/CalculationExtensions.cs
@@ -9,14 +9,24 @@ namespace Circle.Game.Rulesets.Extensions
 {
     public static class CalculationExtensions
     {
+        /// <summary>
+        /// 각도와 타일의 폭으로 다음 타일의 위치를 계산합니다.
+        /// </summary>
+        /// <param name="angle">각도.</param>
+        /// <returns>다음 타일의 위치.</returns>
         public static Vector2 GetComputedTilePosition(float angle)
         {
-            var x = (float)Math.Cos(MathHelper.DegreesToRadians(angle)) * 100;
-            var y = (float)Math.Sin(MathHelper.DegreesToRadians(angle)) * 100;
+            var x = (float)Math.Cos(MathHelper.DegreesToRadians(angle)) * (Tile.WIDTH - Tile.HEIGHT);
+            var y = (float)Math.Sin(MathHelper.DegreesToRadians(angle)) * (Tile.WIDTH - Tile.HEIGHT);
 
             return new Vector2(x, y);
         }
 
+        /// <summary>
+        /// 60분법 범위사이의 각도로 클램프 합니다.
+        /// </summary>
+        /// <param name="angle">각도.</param>
+        /// <returns>60분법 범위의 각도</returns>
         public static float GetSafeAngle(float angle)
         {
             if (angle < 0)
@@ -36,13 +46,22 @@ namespace Circle.Game.Rulesets.Extensions
             return angle;
         }
 
+        /// <summary>
+        /// 행성이 타일에 도착하는 시간을 계산합니다
+        /// </summary>
+        /// <param name="beatmap">비트맵.</param>
+        /// <param name="gameplayStartTime">게임 시작 시간.</param>
+        /// <returns>행성이 타일이 도착하는 시간의 집합.</returns>
         public static IReadOnlyList<double> GetTileHitTime(Beatmap beatmap, double gameplayStartTime)
         {
             var tilesInfo = GetTilesInfo(beatmap).ToArray();
-            List<double> hitStartTimes = new List<double> { tilesInfo[0].Angle - 180 };
             double startTimeOffset = gameplayStartTime;
             float bpm = beatmap.Settings.Bpm;
-            float prevAngle = GetSafeAngle(tilesInfo[0].Angle - 180);
+
+            // 한 박자 앞에서 시작합니다.
+            float prevAngle = tilesInfo[0].Angle - 180;
+            startTimeOffset += GetRelativeDuration(prevAngle, tilesInfo[0].Angle, bpm);
+            List<double> hitStartTimes = new List<double> { startTimeOffset };
 
             for (int floor = 1; floor < tilesInfo.Length; floor++)
             {
@@ -57,6 +76,13 @@ namespace Circle.Game.Rulesets.Extensions
             return hitStartTimes;
         }
 
+        /// <summary>
+        /// 행성이 공전하는 것처럼 보이기 위해 각도를 계산합니다.
+        /// </summary>
+        /// <param name="tilesInfo">타일 정보들.</param>
+        /// <param name="floor">현재 타일.</param>
+        /// <param name="prevAngle">이전 타일 각도.</param>
+        /// <returns>fixedRotation: 행성이 회전하기 전 각도. newRotation: 행성이 회전할 각도.</returns>
         public static (float fixedRotation, float newRotation) ComputeRotation(TileInfo[] tilesInfo, int floor, float prevAngle)
         {
             var currentAngle = GetSafeAngle(tilesInfo[floor].Angle);
@@ -97,6 +123,12 @@ namespace Circle.Game.Rulesets.Extensions
             return (fixedRotation, newRotation);
         }
 
+        /// <summary>
+        /// 행성이 특정 타일에서 회전방뱡을 구합니다.
+        /// </summary>
+        /// <param name="tilesInfo">타일 정보.</param>
+        /// <param name="floor">현재 타일</param>
+        /// <returns>타일이 시계방향으로 회전하는지 여부.</returns>
         public static bool GetIsClockwise(TileInfo[] tilesInfo, int floor)
         {
             bool isClockwise = true;
@@ -111,6 +143,13 @@ namespace Circle.Game.Rulesets.Extensions
             return isClockwise;
         }
 
+        /// <summary>
+        /// 타일의 bpm을 적용합니다.
+        /// </summary>
+        /// <param name="tilesInfo">타일 정보.</param>
+        /// <param name="bpm">현재 bpm.</param>
+        /// <param name="floor">현재 타일.</param>
+        /// <returns>현재bpm에서 승수가 적용된 값 또는 새로운 bpm.</returns>
         public static float GetNewBpm(TileInfo[] tilesInfo, float bpm, int floor)
         {
             switch (tilesInfo[floor].SpeedType)
@@ -126,11 +165,24 @@ namespace Circle.Game.Rulesets.Extensions
             }
         }
 
+        /// <summary>
+        /// 회전 각도와 상관없이 일정한 속도로 회전할 수 있는 시간을 계산합니다.
+        /// </summary>
+        /// <param name="oldRotation">이전 각도.</param>
+        /// <param name="newRotation">새로운 각도.</param>
+        /// <param name="bpm">현재 bpm.</param>
+        /// <returns>계산된 시간.</returns>
         public static float GetRelativeDuration(float oldRotation, float newRotation, float bpm)
         {
             return 60000 / bpm * Math.Abs(oldRotation - newRotation) / 180;
         }
 
+        /// <summary>
+        /// <paramref name="angleData"/>로 타일 타입을 구분합니다.
+        /// 마지막 타일 타입은 <see cref="TileType.Circular"/>입니다.
+        /// </summary>
+        /// <param name="angleData">각도 데이터.</param>
+        /// <returns>타일 타입의 집합.</returns>
         public static IReadOnlyList<TileType> GetTileType(float[] angleData)
         {
             List<TileType> tileTypes = new List<TileType>();
@@ -177,6 +229,11 @@ namespace Circle.Game.Rulesets.Extensions
             return tileTypes;
         }
 
+        /// <summary>
+        /// 타일의 위치를 계산합니다.
+        /// </summary>
+        /// <param name="angleData">각도 데이터.</param>
+        /// <returns>각 타일의 위치의 집합.</returns>
         public static IReadOnlyList<Vector2> GetTilePositions(float[] angleData)
         {
             var types = GetTileType(angleData);
@@ -215,6 +272,11 @@ namespace Circle.Game.Rulesets.Extensions
             return positions;
         }
 
+        /// <summary>
+        /// 타일의 정보를 가져옵니다.
+        /// </summary>
+        /// <param name="beatmap">비트맵.</param>
+        /// <returns>각 타일 정보에 대한 집합.</returns>
         public static IReadOnlyList<TileInfo> GetTilesInfo(Beatmap beatmap)
         {
             TileInfo[] infos = new TileInfo[beatmap.AngleData.Length];
@@ -275,11 +337,17 @@ namespace Circle.Game.Rulesets.Extensions
             return infos;
         }
 
-        public static float GetAvailableAngle(float[] angleData, int index)
+        /// <summary>
+        /// 각도 값이 999(미드스핀)일 때 이전의 각도로 수정합니다.
+        /// </summary>
+        /// <param name="angleData">각도 데이터.</param>
+        /// <param name="floor">현재 타일.</param>
+        /// <returns>수정된 각도.</returns>
+        public static float GetAvailableAngle(float[] angleData, int floor)
         {
             var availableAngle = 0f;
 
-            for (int i = index - 1; i >= 0; i--)
+            for (int i = floor - 1; i >= 0; i--)
             {
                 if (angleData[i] != 999)
                 {
@@ -293,6 +361,11 @@ namespace Circle.Game.Rulesets.Extensions
             return availableAngle;
         }
 
+        /// <summary>
+        /// Adofai에서 사용하는 각도 방향을 우리가 원하는 방향으로 반전합니다.
+        /// </summary>
+        /// <param name="targetAngleData">Adofai 각도 데이터.</param>
+        /// <returns>반전된 값의 각도 데이터.</returns>
         public static float[] ConvertAngles(float[] targetAngleData)
         {
             List<float> newAngleData = new List<float>();

--- a/Circle.Game/Rulesets/Extensions/CalculationExtensions.cs
+++ b/Circle.Game/Rulesets/Extensions/CalculationExtensions.cs
@@ -251,7 +251,6 @@ namespace Circle.Game.Rulesets.Extensions
                         break;
 
                     case TileType.Midspin:
-
                         offset -= GetComputedTilePosition(GetAvailableAngle(angleData, i));
                         break;
 
@@ -279,12 +278,12 @@ namespace Circle.Game.Rulesets.Extensions
         /// <returns>각 타일 정보에 대한 집합.</returns>
         public static IReadOnlyList<TileInfo> GetTilesInfo(Beatmap beatmap)
         {
-            TileInfo[] infos = new TileInfo[beatmap.AngleData.Length];
             var convertedAngleData = ConvertAngles(beatmap.AngleData);
+            TileInfo[] infos = new TileInfo[convertedAngleData.Length];
             var types = GetTileType(convertedAngleData);
             var tilePositions = GetTilePositions(convertedAngleData);
 
-            for (int floor = 0; floor < beatmap.AngleData.Length; floor++)
+            for (int floor = 0; floor < convertedAngleData.Length; floor++)
             {
                 infos[floor] = new TileInfo
                 {
@@ -363,6 +362,7 @@ namespace Circle.Game.Rulesets.Extensions
 
         /// <summary>
         /// Adofai에서 사용하는 각도 방향을 우리가 원하는 방향으로 반전합니다.
+        /// 마지막 타일이 추가로 있어야 하기때문에 하나 더 추가됩니다.
         /// </summary>
         /// <param name="targetAngleData">Adofai 각도 데이터.</param>
         /// <returns>반전된 값의 각도 데이터.</returns>

--- a/Circle.Game/Rulesets/Extensions/CalculationExtensions.cs
+++ b/Circle.Game/Rulesets/Extensions/CalculationExtensions.cs
@@ -1,4 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Circle.Game.Beatmaps;
+using Circle.Game.Rulesets.Objects;
 using osuTK;
 
 namespace Circle.Game.Rulesets.Extensions
@@ -30,6 +34,286 @@ namespace Circle.Game.Rulesets.Extensions
                 angle -= 360;
 
             return angle;
+        }
+
+        public static IReadOnlyList<double> GetTileHitTime(Beatmap beatmap, double gameplayStartTime)
+        {
+            var tilesInfo = GetTilesInfo(beatmap).ToArray();
+            List<double> hitStartTimes = new List<double> { tilesInfo[0].Angle - 180 };
+            double startTimeOffset = gameplayStartTime;
+            float bpm = beatmap.Settings.Bpm;
+            float prevAngle = GetSafeAngle(tilesInfo[0].Angle - 180);
+
+            for (int floor = 1; floor < tilesInfo.Length; floor++)
+            {
+                var (fixedRotation, newRotation) = ComputeRotation(tilesInfo, floor, prevAngle);
+
+                prevAngle = newRotation;
+                bpm = GetNewBpm(tilesInfo, bpm, floor);
+                startTimeOffset += GetRelativeDuration(fixedRotation, newRotation, bpm);
+                hitStartTimes.Add(startTimeOffset);
+            }
+
+            return hitStartTimes;
+        }
+
+        public static (float fixedRotation, float newRotation) ComputeRotation(TileInfo[] tilesInfo, int floor, float prevAngle)
+        {
+            var currentAngle = GetSafeAngle(tilesInfo[floor].Angle);
+
+            // 소용돌이에 대한 아무런 설정이 없으면 시계방향으로 회전합니다.
+            bool isClockwise = GetIsClockwise(tilesInfo, floor + 1);
+
+            float fixedRotation = GetSafeAngle(prevAngle);
+
+            // 현재와 이전 타일이 미드스핀 타일일 때 회전각을 반전하면 안됩니다.
+            if (floor > 0)
+            {
+                if (tilesInfo[floor].TileType != TileType.Midspin && tilesInfo[floor - 1].TileType != TileType.Midspin)
+                    fixedRotation -= 180;
+                else if (tilesInfo[floor].TileType == TileType.Midspin && tilesInfo[floor - 1].TileType == TileType.Midspin)
+                    fixedRotation -= 180;
+            }
+
+            if (tilesInfo[floor].TileType == TileType.Midspin)
+                return (fixedRotation, fixedRotation);
+
+            float newRotation = currentAngle >= 180 ? currentAngle - 360 : currentAngle;
+
+            // 회전방향에 따라 새로운 각도 계산
+            if (isClockwise)
+            {
+                while (fixedRotation >= newRotation)
+                    newRotation += 360;
+            }
+            else
+            {
+                newRotation = currentAngle >= 180 ? currentAngle : newRotation;
+
+                while (fixedRotation <= newRotation)
+                    newRotation -= 360;
+            }
+
+            return (fixedRotation, newRotation);
+        }
+
+        public static bool GetIsClockwise(TileInfo[] tilesInfo, int floor)
+        {
+            bool isClockwise = true;
+
+            // 소용돌이를 적용합니다.
+            for (int i = 0; i < floor; i++)
+            {
+                if (tilesInfo[i].Twirl)
+                    isClockwise = !isClockwise;
+            }
+
+            return isClockwise;
+        }
+
+        public static float GetNewBpm(TileInfo[] tilesInfo, float bpm, int floor)
+        {
+            switch (tilesInfo[floor].SpeedType)
+            {
+                case SpeedType.Multiplier:
+                    return bpm * tilesInfo[floor].BpmMultiplier;
+
+                case SpeedType.Bpm:
+                    return tilesInfo[floor].Bpm;
+
+                default:
+                    return bpm;
+            }
+        }
+
+        public static float GetRelativeDuration(float oldRotation, float newRotation, float bpm)
+        {
+            return 60000 / bpm * Math.Abs(oldRotation - newRotation) / 180;
+        }
+
+        public static IReadOnlyList<TileType> GetTileType(float[] angleData)
+        {
+            List<TileType> tileTypes = new List<TileType>();
+
+            for (int floor = 0; floor < angleData.Length; floor++)
+            {
+                if (floor + 1 < angleData.Length)
+                {
+                    if (angleData[floor + 1] == 999 && angleData[floor] != 999)
+                    {
+                        tileTypes.Add(TileType.Short);
+                        continue;
+                    }
+                    else if (Math.Abs(angleData[floor] - angleData[floor + 1]) == 180)
+                    {
+                        tileTypes.Add(TileType.Short);
+                        continue;
+                    }
+                    else if (floor > 0)
+                    {
+                        if (Math.Abs(angleData[floor] - angleData[floor - 1]) == 180)
+                        {
+                            tileTypes.Add(TileType.Circular);
+                            continue;
+                        }
+                    }
+                }
+                else
+                {
+                    // 마지막 타일을 의미합니다.
+                    tileTypes.Add(TileType.Circular);
+                    break;
+                }
+
+                if (angleData[floor] == 999)
+                {
+                    tileTypes.Add(TileType.Midspin);
+                    continue;
+                }
+
+                tileTypes.Add(TileType.Normal);
+            }
+
+            return tileTypes;
+        }
+
+        public static IReadOnlyList<Vector2> GetTilePositions(float[] angleData)
+        {
+            var types = GetTileType(angleData);
+            var positions = new List<Vector2> { Vector2.Zero };
+            Vector2 offset = Vector2.Zero;
+
+            for (int i = 0; i < angleData.Length; i++)
+            {
+                var newTilePosition = GetComputedTilePosition(angleData[i]);
+
+                switch (types[i])
+                {
+                    case TileType.Normal:
+                        offset += newTilePosition;
+                        break;
+
+                    case TileType.Midspin:
+
+                        offset -= GetComputedTilePosition(GetAvailableAngle(angleData, i));
+                        break;
+
+                    case TileType.Short:
+                        offset += newTilePosition;
+                        break;
+
+                    case TileType.Circular:
+                        if (i + 1 < angleData.Length)
+                            offset += newTilePosition;
+
+                        break;
+                }
+
+                positions.Add(offset);
+            }
+
+            return positions;
+        }
+
+        public static IReadOnlyList<TileInfo> GetTilesInfo(Beatmap beatmap)
+        {
+            TileInfo[] infos = new TileInfo[beatmap.AngleData.Length];
+            var convertedAngleData = ConvertAngles(beatmap.AngleData);
+            var types = GetTileType(convertedAngleData);
+            var tilePositions = GetTilePositions(convertedAngleData);
+
+            for (int floor = 0; floor < beatmap.AngleData.Length; floor++)
+            {
+                infos[floor] = new TileInfo
+                {
+                    TileType = types[floor],
+                    Floor = floor,
+                    Angle = types[floor] == TileType.Midspin ? GetAvailableAngle(convertedAngleData, floor) : convertedAngleData[floor],
+                    Position = tilePositions[floor],
+                };
+            }
+
+            foreach (var action in beatmap.Actions)
+            {
+                infos[action.Floor].EventType = action.EventType;
+
+                switch (action.EventType)
+                {
+                    case EventType.Twirl:
+                        infos[action.Floor].Twirl = true;
+                        break;
+
+                    case EventType.SetSpeed:
+                        switch (action.SpeedType)
+                        {
+                            case SpeedType.Multiplier:
+                                infos[action.Floor].SpeedType = SpeedType.Multiplier;
+                                infos[action.Floor].BpmMultiplier = action.BpmMultiplier;
+                                break;
+
+                            case SpeedType.Bpm:
+                                infos[action.Floor].SpeedType = SpeedType.Bpm;
+                                infos[action.Floor].Bpm = action.BeatsPerMinute;
+                                break;
+                        }
+
+                        break;
+
+                    case EventType.SetPlanetRotation:
+                        infos[action.Floor].Easing = action.Ease;
+                        break;
+
+                    case EventType.MoveCamera:
+                        // Todo: 카메라 기능 추가
+                        break;
+
+                    case EventType.Other:
+                        break;
+                }
+            }
+
+            return infos;
+        }
+
+        public static float GetAvailableAngle(float[] angleData, int index)
+        {
+            var availableAngle = 0f;
+
+            for (int i = index - 1; i >= 0; i--)
+            {
+                if (angleData[i] != 999)
+                {
+                    availableAngle += angleData[i];
+                    break;
+                }
+                else
+                    availableAngle += 180;
+            }
+
+            return availableAngle;
+        }
+
+        public static float[] ConvertAngles(float[] targetAngleData)
+        {
+            List<float> newAngleData = new List<float>();
+
+            for (int i = 0; i < targetAngleData.Length; i++)
+            {
+                if (targetAngleData[i] == 999 || targetAngleData[i] <= 0)
+                {
+                    if (targetAngleData[i] >= 0)
+                        newAngleData.Add(targetAngleData[i]);
+                    else
+                        newAngleData.Add(newAngleData[i - 1] - 180);
+                    continue;
+                }
+
+                newAngleData.Add(360 - targetAngleData[i]);
+            }
+
+            newAngleData.Add(360 - targetAngleData.Last());
+
+            return newAngleData.ToArray();
         }
     }
 }

--- a/Circle.Game/Screens/Play/GameProgressBar.cs
+++ b/Circle.Game/Screens/Play/GameProgressBar.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Threading;
+using osuTK.Graphics;
+
+namespace Circle.Game.Screens.Play
+{
+    public class GameProgressBar : SliderBar<int>
+    {
+        public Action<double> OnSeek;
+
+        public bool Seekable;
+        public float Duration;
+
+        private readonly Box fill;
+
+        public Color4 FillColour
+        {
+            set => fill.Colour = value;
+        }
+
+        public int StartFloor
+        {
+            set => CurrentNumber.MinValue = value;
+        }
+
+        public int EndFloor
+        {
+            set => CurrentNumber.MaxValue = value;
+        }
+
+        public int CurrentFloor
+        {
+            set => CurrentNumber.Value = value;
+        }
+
+        public GameProgressBar(float barHeight, float handleBarHeight)
+        {
+            CurrentNumber.MinValue = 0;
+            CurrentNumber.MaxValue = 1;
+
+            RelativeSizeAxes = Axes.X;
+            Height = barHeight + handleBarHeight;
+
+            Children = new Drawable[]
+            {
+                new Box
+                {
+                    Name = "Background",
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.BottomLeft,
+                    RelativeSizeAxes = Axes.X,
+                    Height = barHeight,
+                    Colour = Color4.Black,
+                    Alpha = 0.4f,
+                    Depth = 1,
+                },
+                fill = new Box
+                {
+                    Name = "Fill",
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.BottomLeft,
+                    Height = barHeight,
+                },
+            };
+        }
+
+        protected override void UpdateValue(float value)
+        {
+            // handled in update
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            fill.ResizeWidthTo(UsableWidth / CurrentNumber.MaxValue * CurrentNumber.Value, Duration, Easing.OutQuint);
+            //fill.Width = newX;
+        }
+
+        private ScheduledDelegate scheduledSeek;
+
+        protected override void OnUserChange(int value)
+        {
+            scheduledSeek?.Cancel();
+            scheduledSeek = Schedule(() =>
+            {
+                if (Seekable)
+                    OnSeek?.Invoke(value);
+            });
+        }
+    }
+}

--- a/Circle.Game/Screens/Play/ObjectContainer.cs
+++ b/Circle.Game/Screens/Play/ObjectContainer.cs
@@ -13,7 +13,7 @@ namespace Circle.Game.Screens.Play
 {
     public class ObjectContainer : Container<Tile>
     {
-        private float[] angleData => convertAngles(currentBeatmap.AngleData);
+        private float[] angleData => CalculationExtensions.ConvertAngles(currentBeatmap.AngleData);
 
         private readonly Beatmap currentBeatmap;
 
@@ -85,148 +85,13 @@ namespace Circle.Game.Screens.Play
             addActionsToTile();
         }
 
-        private IReadOnlyList<TileType> getTileType()
-        {
-            List<TileType> tileTypes = new List<TileType>();
+        private IReadOnlyList<TileType> getTileType() => CalculationExtensions.GetTileType(angleData);
 
-            for (int floor = 0; floor < angleData.Length; floor++)
-            {
-                if (floor + 1 < angleData.Length)
-                {
-                    if (angleData[floor + 1] == 999 && angleData[floor] != 999)
-                    {
-                        tileTypes.Add(TileType.Short);
-                        continue;
-                    }
-                    else if (Math.Abs(angleData[floor] - angleData[floor + 1]) == 180)
-                    {
-                        tileTypes.Add(TileType.Short);
-                        continue;
-                    }
-                    else if (floor > 0)
-                    {
-                        if (Math.Abs(angleData[floor] - angleData[floor - 1]) == 180)
-                        {
-                            tileTypes.Add(TileType.Circular);
-                            continue;
-                        }
-                    }
-                }
-                else
-                {
-                    // 마지막 타일을 의미합니다.
-                    tileTypes.Add(TileType.Circular);
-                    break;
-                }
+        private IReadOnlyList<Vector2> getTilePositions() => CalculationExtensions.GetTilePositions(angleData);
 
-                if (angleData[floor] == 999)
-                {
-                    tileTypes.Add(TileType.Midspin);
-                    continue;
-                }
+        public IReadOnlyList<TileInfo> GetTilesInfo() => CalculationExtensions.GetTilesInfo(currentBeatmap);
 
-                tileTypes.Add(TileType.Normal);
-            }
-
-            return tileTypes;
-        }
-
-        private IReadOnlyList<Vector2> getTilePositions()
-        {
-            var types = getTileType();
-            var positions = new List<Vector2> { Vector2.Zero };
-            Vector2 offset = Vector2.Zero;
-
-            for (int i = 0; i < angleData.Length; i++)
-            {
-                var newTilePosition = CalculationExtensions.GetComputedTilePosition(angleData[i]);
-
-                switch (types[i])
-                {
-                    case TileType.Normal:
-                        offset += newTilePosition;
-                        break;
-
-                    case TileType.Midspin:
-
-                        offset -= CalculationExtensions.GetComputedTilePosition(getAvailableAngle(i));
-                        break;
-
-                    case TileType.Short:
-                        offset += newTilePosition;
-                        break;
-
-                    case TileType.Circular:
-                        if (i + 1 < angleData.Length)
-                            offset += newTilePosition;
-
-                        break;
-                }
-
-                positions.Add(offset);
-            }
-
-            return positions;
-        }
-
-        public IReadOnlyList<TileInfo> GetTilesInfo()
-        {
-            TileInfo[] infos = new TileInfo[angleData.Length];
-            var types = getTileType();
-            var tilePositions = getTilePositions();
-
-            for (int floor = 0; floor < angleData.Length; floor++)
-            {
-                infos[floor] = new TileInfo
-                {
-                    TileType = types[floor],
-                    Floor = floor,
-                    Angle = types[floor] == TileType.Midspin ? getAvailableAngle(floor) : angleData[floor],
-                    Position = tilePositions[floor],
-                };
-            }
-
-            foreach (var action in currentBeatmap.Actions)
-            {
-                infos[action.Floor].EventType = action.EventType;
-
-                switch (action.EventType)
-                {
-                    case EventType.Twirl:
-                        infos[action.Floor].Twirl = true;
-                        break;
-
-                    case EventType.SetSpeed:
-                        switch (action.SpeedType)
-                        {
-                            case SpeedType.Multiplier:
-                                infos[action.Floor].SpeedType = SpeedType.Multiplier;
-                                infos[action.Floor].BpmMultiplier = action.BpmMultiplier;
-                                break;
-
-                            case SpeedType.Bpm:
-                                infos[action.Floor].SpeedType = SpeedType.Bpm;
-                                infos[action.Floor].Bpm = action.BeatsPerMinute;
-                                break;
-                        }
-
-                        break;
-
-                    case EventType.SetPlanetRotation:
-                        infos[action.Floor].Easing = action.Ease;
-                        break;
-
-                    case EventType.MoveCamera:
-                        // Todo: 카메라 기능 추가
-                        break;
-
-                    case EventType.Other:
-                        break;
-                }
-            }
-
-            return infos;
-        }
+        private float getAvailableAngle(int floor) => CalculationExtensions.GetAvailableAngle(angleData, floor);
 
         private void addActionsToTile()
         {
@@ -274,52 +139,6 @@ namespace Circle.Game.Screens.Play
                         break;
                 }
             }
-        }
-
-        private float getAvailableAngle(int index)
-        {
-            var availableAngle = 0f;
-
-            for (int i = index - 1; i >= 0; i--)
-            {
-                if (angleData[i] != 999)
-                {
-                    availableAngle += angleData[i];
-                    break;
-                }
-                else
-                    availableAngle += 180;
-            }
-
-            return availableAngle;
-        }
-
-        /// <summary>
-        /// 반시계 방향으로 되어있는 각도데이터를 시계방향으로 변환합니다.
-        /// </summary>
-        /// <param name="targetAngleData"></param>
-        /// <returns>시계방향으로 변환된 각도데이터.</returns>
-        private float[] convertAngles(float[] targetAngleData)
-        {
-            List<float> newAngleData = new List<float>();
-
-            for (int i = 0; i < targetAngleData.Length; i++)
-            {
-                if (targetAngleData[i] == 999 || targetAngleData[i] <= 0)
-                {
-                    if (targetAngleData[i] >= 0)
-                        newAngleData.Add(targetAngleData[i]);
-                    else
-                        newAngleData.Add(newAngleData[i - 1] - 180);
-                    continue;
-                }
-
-                newAngleData.Add(360 - targetAngleData[i]);
-            }
-
-            newAngleData.Add(360 - targetAngleData.Last());
-
-            return newAngleData.ToArray();
         }
     }
 }

--- a/Circle.Game/Screens/Play/ObjectContainer.cs
+++ b/Circle.Game/Screens/Play/ObjectContainer.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using Circle.Game.Beatmaps;
 using Circle.Game.Rulesets.Extensions;
 using Circle.Game.Rulesets.Objects;

--- a/Circle.Game/Screens/Play/Player.cs
+++ b/Circle.Game/Screens/Play/Player.cs
@@ -4,6 +4,7 @@ using Circle.Game.Beatmaps;
 using Circle.Game.Configuration;
 using Circle.Game.Graphics.UserInterface;
 using Circle.Game.Overlays;
+using Circle.Game.Rulesets.Extensions;
 using Circle.Game.Screens.Setting;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -74,6 +75,7 @@ namespace Circle.Game.Screens.Play
         private readonly Beatmap currentBeatmap;
 
         private bool parallaxEnabled;
+        private double endTime;
 
         public Player(BeatmapInfo beatmapInfo)
         {
@@ -87,6 +89,7 @@ namespace Circle.Game.Screens.Play
             parallaxEnabled = localConfig.Get<bool>(CircleSetting.Parallax);
             texureSource = background.TextureSource;
             textureName = background.TextureName;
+            endTime = CalculationExtensions.GetTileHitTime(currentBeatmap, currentBeatmap.Settings.Offset - 60000 / currentBeatmap.Settings.Bpm).Last();
             InternalChildren = new Drawable[]
             {
                 masterGameplayClockContainer = new MasterGameplayClockContainer(beatmapInfo, Clock),
@@ -171,7 +174,7 @@ namespace Circle.Game.Screens.Play
         {
             base.Update();
 
-            if (masterGameplayClockContainer.CurrentTime >= masterGameplayClockContainer.Playfield.EndTime)
+            if (masterGameplayClockContainer.CurrentTime >= endTime)
             {
                 playState = GamePlayState.Complete;
                 dialog.BlockInputAction = false;

--- a/Circle.Game/Screens/Play/Playfield.cs
+++ b/Circle.Game/Screens/Play/Playfield.cs
@@ -261,12 +261,6 @@ namespace Circle.Game.Screens.Play
             }
         }
 
-        /// <summary>
-        /// 현재 타일로 자연스럽게 회전할 수 있는 각도를 제공합니다.
-        /// </summary>
-        /// <param name="floor">현재 타일 번호.</param>
-        /// <param name="previousAngle">이전 타일 각도.</param>
-        /// <returns>변환된 각도. (회전 전 각도, 회전 후 각도)</returns>
         private (float fixedRotation, float newRotation) computeRotation(int floor, float prevAngle) => CalculationExtensions.ComputeRotation(tilesInfo, floor, prevAngle);
 
         private RotationDirection getIsClockwise(int floor) => CalculationExtensions.GetIsClockwise(tilesInfo, floor) ? RotationDirection.Clockwise : RotationDirection.Counterclockwise;

--- a/Circle.Game/Screens/Play/Playfield.cs
+++ b/Circle.Game/Screens/Play/Playfield.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using Circle.Game.Beatmaps;
-using Circle.Game.Graphics.UserInterface;
 using Circle.Game.Rulesets.Extensions;
 using Circle.Game.Rulesets.Objects;
 using osu.Framework.Allocation;

--- a/Circle.Game/Screens/Play/Playfield.cs
+++ b/Circle.Game/Screens/Play/Playfield.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using Circle.Game.Beatmaps;
+using Circle.Game.Graphics.UserInterface;
 using Circle.Game.Rulesets.Extensions;
 using Circle.Game.Rulesets.Objects;
 using osu.Framework.Allocation;
@@ -18,8 +19,6 @@ namespace Circle.Game.Screens.Play
         private Container<Planet> planetContainer;
 
         private TileInfo[] tilesInfo;
-
-        private bool isClockwise;
 
         public Action OnComplete { get; set; }
 
@@ -61,7 +60,6 @@ namespace Circle.Game.Screens.Play
             };
 
             tilesInfo = tileContainer.GetTilesInfo().ToArray();
-            isClockwise = true;
             redPlanet.Expansion = bluePlanet.Expansion = 0;
             bluePlanet.Rotation = tilesInfo.First().Angle - 180;
         }
@@ -80,7 +78,7 @@ namespace Circle.Game.Screens.Play
             PlanetState planetState = PlanetState.Ice;
 
             double startTimeOffset = gameplayStartTime;
-            float previousAngle;
+            float prevAngle;
             float bpm = currentBeatmap.Settings.Bpm;
             int floor = 0;
             Easing easing = Easing.None;
@@ -89,14 +87,14 @@ namespace Circle.Game.Screens.Play
 
             using (bluePlanet.BeginAbsoluteSequence(startTimeOffset))
             {
-                startTimeOffset += GetRelativeDuration(bluePlanet.Rotation, tilesInfo[floor].Angle, bpm);
+                startTimeOffset += CalculationExtensions.GetRelativeDuration(bluePlanet.Rotation, tilesInfo[floor].Angle, bpm);
                 bluePlanet.ExpandTo(1, 60000 / bpm, Easing.Out);
-                bluePlanet.RotateTo(tilesInfo[floor].Angle, GetRelativeDuration(bluePlanet.Rotation, tilesInfo[floor].Angle, bpm), easing);
+                bluePlanet.RotateTo(tilesInfo[floor].Angle, CalculationExtensions.GetRelativeDuration(bluePlanet.Rotation, tilesInfo[floor].Angle, bpm), easing);
             }
 
             using (bluePlanet.BeginAbsoluteSequence(startTimeOffset))
             {
-                previousAngle = tilesInfo[floor].Angle;
+                prevAngle = tilesInfo[floor].Angle;
                 floor++;
 
                 if (floor < tilesInfo.Length)
@@ -122,9 +120,9 @@ namespace Circle.Game.Screens.Play
                 using (BeginAbsoluteSequence(startTimeOffset, false))
                     this.ScaleTo(1.02f).ScaleTo(1, 500 + 100 / bpm * 500, Easing.OutSine);
 
-                var (fixedRotation, newRotation) = computeRotation(floor, previousAngle);
-                bpm = getNewBpm(bpm, floor, tilesInfo[floor].SpeedType);
-                previousAngle = newRotation;
+                var (fixedRotation, newRotation) = computeRotation(floor, prevAngle);
+                bpm = getNewBpm(bpm, floor);
+                prevAngle = newRotation;
 
                 if (tilesInfo[floor].EventType == EventType.SetPlanetRotation)
                     easing = tilesInfo[floor].Easing;
@@ -138,7 +136,7 @@ namespace Circle.Game.Screens.Play
                         {
                             redPlanet.ExpandTo(1);
                             redPlanet.RotateTo(fixedRotation);
-                            redPlanet.RotateTo(newRotation, GetRelativeDuration(fixedRotation, newRotation, bpm), easing);
+                            redPlanet.RotateTo(newRotation, CalculationExtensions.GetRelativeDuration(fixedRotation, newRotation, bpm), easing);
                         }
 
                         break;
@@ -148,7 +146,7 @@ namespace Circle.Game.Screens.Play
                         {
                             bluePlanet.ExpandTo(1);
                             bluePlanet.RotateTo(fixedRotation);
-                            bluePlanet.RotateTo(newRotation, GetRelativeDuration(fixedRotation, newRotation, bpm), easing);
+                            bluePlanet.RotateTo(newRotation, CalculationExtensions.GetRelativeDuration(fixedRotation, newRotation, bpm), easing);
                         }
 
                         break;
@@ -157,7 +155,7 @@ namespace Circle.Game.Screens.Play
                 #endregion
 
                 // 회전을 마치면 다른 행성으로 회전할 준비를 해야합니다.
-                startTimeOffset += GetRelativeDuration(fixedRotation, newRotation, bpm);
+                startTimeOffset += CalculationExtensions.GetRelativeDuration(fixedRotation, newRotation, bpm);
                 floor++;
 
                 #region Planet reducation
@@ -197,7 +195,7 @@ namespace Circle.Game.Screens.Play
                             using (redPlanet.BeginAbsoluteSequence(startTimeOffset, false))
                             {
                                 redPlanet.ExpandTo(1);
-                                redPlanet.Spin(60000 / bpm * 2, isClockwise ? RotationDirection.Clockwise : RotationDirection.Counterclockwise, previousAngle);
+                                redPlanet.Spin(60000 / bpm * 2, getIsClockwise(floor), prevAngle);
                             }
 
                             break;
@@ -206,7 +204,7 @@ namespace Circle.Game.Screens.Play
                             using (bluePlanet.BeginAbsoluteSequence(startTimeOffset, false))
                             {
                                 bluePlanet.ExpandTo(1);
-                                bluePlanet.Spin(60000 / bpm * 2, isClockwise ? RotationDirection.Clockwise : RotationDirection.Counterclockwise, previousAngle);
+                                bluePlanet.Spin(60000 / bpm * 2, getIsClockwise(floor), prevAngle);
                             }
 
                             break;
@@ -214,7 +212,7 @@ namespace Circle.Game.Screens.Play
                 }
             }
 
-            startTimeOffset -= GetRelativeDuration(previousAngle, previousAngle - 180, bpm);
+            startTimeOffset -= CalculationExtensions.GetRelativeDuration(prevAngle, prevAngle - 180, bpm);
             EndTime = startTimeOffset;
         }
 
@@ -230,29 +228,28 @@ namespace Circle.Game.Screens.Play
             // Fade in
             for (int i = 8; i < tilesInfo.Length; i++)
             {
-                var (fixedRotation, newRotation) = computeRotation(tilesInfo[i - 8].Floor, previousAngle);
+                var (fixedRotation, newRotation) = computeRotation(i - 8, previousAngle);
 
                 previousAngle = newRotation;
-                bpm = getNewBpm(bpm, tilesInfo[i - 8].Floor, tilesInfo[i - 8].SpeedType);
+                bpm = getNewBpm(bpm, i - 8);
 
                 using (tileContainer.Children[i].BeginAbsoluteSequence(startTimeOffset, false))
                     tileContainer.Children[i].FadeTo(0.45f, 60000 / bpm, Easing.Out);
 
-                startTimeOffset += GetRelativeDuration(fixedRotation, newRotation, bpm);
+                startTimeOffset += CalculationExtensions.GetRelativeDuration(fixedRotation, newRotation, bpm);
             }
 
             startTimeOffset = gameplayStartTime;
             bpm = currentBeatmap.Settings.Bpm;
             previousAngle = CalculationExtensions.GetSafeAngle(tilesInfo.First().Angle - 180);
-            isClockwise = true;
 
             // Fade out
             for (int i = 0; i < tilesInfo.Length; i++)
             {
-                var (fixedRotation, newRotation) = computeRotation(tilesInfo[i].Floor, previousAngle);
+                var (fixedRotation, newRotation) = computeRotation(i, previousAngle);
 
                 previousAngle = newRotation;
-                bpm = getNewBpm(bpm, tilesInfo[i].Floor, tilesInfo[i].SpeedType);
+                bpm = getNewBpm(bpm, i);
 
                 if (i > 3)
                 {
@@ -260,10 +257,8 @@ namespace Circle.Game.Screens.Play
                         tileContainer.Children[i - 4].FadeOut(60000 / bpm, Easing.Out).Then().Expire();
                 }
 
-                startTimeOffset += GetRelativeDuration(fixedRotation, newRotation, bpm);
+                startTimeOffset += CalculationExtensions.GetRelativeDuration(fixedRotation, newRotation, bpm);
             }
-
-            isClockwise = true;
         }
 
         /// <summary>
@@ -272,65 +267,10 @@ namespace Circle.Game.Screens.Play
         /// <param name="floor">현재 타일 번호.</param>
         /// <param name="previousAngle">이전 타일 각도.</param>
         /// <returns>변환된 각도. (회전 전 각도, 회전 후 각도)</returns>
-        private (float fixedRotation, float newRotation) computeRotation(int floor, float previousAngle)
-        {
-            var currentAngle = CalculationExtensions.GetSafeAngle(tilesInfo[floor].Angle);
+        private (float fixedRotation, float newRotation) computeRotation(int floor, float prevAngle) => CalculationExtensions.ComputeRotation(tilesInfo, floor, prevAngle);
 
-            // 소용돌이 적용.
-            if (tilesInfo[floor].Twirl)
-                isClockwise = !isClockwise;
+        private RotationDirection getIsClockwise(int floor) => CalculationExtensions.GetIsClockwise(tilesInfo, floor) ? RotationDirection.Clockwise : RotationDirection.Counterclockwise;
 
-            float fixedRotation = CalculationExtensions.GetSafeAngle(previousAngle);
-
-            // 현재와 이전 타일이 미드스핀 타일일 때 회전각을 반전하면 안됩니다.
-            if (floor > 0)
-            {
-                if (tilesInfo[floor].TileType != TileType.Midspin && tilesInfo[floor - 1].TileType != TileType.Midspin)
-                    fixedRotation -= 180;
-                else if (tilesInfo[floor].TileType == TileType.Midspin && tilesInfo[floor - 1].TileType == TileType.Midspin)
-                    fixedRotation -= 180;
-            }
-
-            if (tilesInfo[floor].TileType == TileType.Midspin)
-                return (fixedRotation, fixedRotation);
-
-            float newRotation = currentAngle >= 180 ? currentAngle - 360 : currentAngle;
-
-            // 회전방향에 따라 새로운 각도 계산
-            if (isClockwise)
-            {
-                while (fixedRotation >= newRotation)
-                    newRotation += 360;
-            }
-            else
-            {
-                newRotation = currentAngle >= 180 ? currentAngle : newRotation;
-
-                while (fixedRotation <= newRotation)
-                    newRotation -= 360;
-            }
-
-            return (fixedRotation, newRotation);
-        }
-
-        private float getNewBpm(float current, int floor, SpeedType? speedType)
-        {
-            switch (speedType)
-            {
-                case SpeedType.Multiplier:
-                    return current * tilesInfo[floor].BpmMultiplier;
-
-                case SpeedType.Bpm:
-                    return tilesInfo[floor].Bpm;
-
-                default:
-                    return current;
-            }
-        }
-
-        public float GetRelativeDuration(float oldRotation, float newRotation, float bpm)
-        {
-            return 60000 / bpm * Math.Abs(oldRotation - newRotation) / 180;
-        }
+        private float getNewBpm(float current, int floor) => CalculationExtensions.GetNewBpm(tilesInfo, current, floor);
     }
 }


### PR DESCRIPTION
# 성능 비교
**측정 환경:**
* CPU: AMD Ryzen 7 5700G
* RAM: DDR4 16GB
* GPU: NVIDIA GeForce GTX 1070

**설정:**
* Screen mode: Windowed
* Frame limiter: Unlimited
* Threading mode: MultiThreaded
* Frame overlay: Off

## 비트맵: Plum - Megamix (https://www.youtube.com/watch?v=nSGSx6ZXNwE&t=621s)
타일 개수: 9452
길이: 약 600초(약 10분)

### 맵 로딩 시간
| 2022.301.0 | 2022.319.0 | This PR |
| :------------: | :------------: | :--------: |
| 125초 | 16초 | 3초 |

### 2022.301.0 - 2022.319.0
맵 로딩: 125초 -> 16초 (**_87.2%_** 감소)

### 2022.319.0 - This PR
맵로딩: 16초 -> 3초 (**_81.2%_** 감소)

### 2022.301.0 - This PR
맵 로딩: 125초 -> 3초 (**_97.6%_** 감소)