### PR TITLE
Implement initial `InputManager`

### DIFF
--- a/Circle.Game/Beatmaps/Beatmap.cs
+++ b/Circle.Game/Beatmaps/Beatmap.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Circle.Game.Rulesets.Extensions;
 using Circle.Game.Rulesets.Objects;
+using Newtonsoft.Json;
 using osu.Framework.Graphics;
 using osu.Framework.Utils;
 
@@ -13,8 +14,16 @@ namespace Circle.Game.Beatmaps
         public float[] AngleData { get; set; }
         public Settings Settings { get; set; }
         public Actions[] Actions { get; set; }
-        public TileInfo[] TilesInfo => CalculationExtensions.GetTilesInfo(this);
-        public IReadOnlyList<double> TileStartTime => CalculationExtensions.GetTileStartTime(this, Settings.Offset, 60000 / Settings.Bpm * Settings.CountdownTicks);
+
+        [JsonIgnore]
+        public TileInfo[] TilesInfo => tilesInfo ??= CalculationExtensions.GetTilesInfo(this);
+
+        private TileInfo[] tilesInfo;
+
+        [JsonIgnore]
+        public IReadOnlyList<double> TileStartTime => tileStartTime ??= CalculationExtensions.GetTileStartTime(this, Settings.Offset, 60000 / Settings.Bpm * Settings.CountdownTicks);
+
+        private IReadOnlyList<double> tileStartTime;
 
         public bool Equals(Beatmap beatmap) => beatmap != null && Settings.Equals(beatmap.Settings) && Actions.SequenceEqual(beatmap.Actions);
     }

--- a/Circle.Game/Overlays/MusicController.cs
+++ b/Circle.Game/Overlays/MusicController.cs
@@ -13,7 +13,7 @@ namespace Circle.Game.Overlays
     public class MusicController : CompositeDrawable
     {
         [NotNull]
-        public DrawableTrack CurrentTrack { get; private set; } = new DrawableTrack(new TrackVirtual(1000));
+        public DrawableTrack CurrentTrack { get; protected set; } = new DrawableTrack(new TrackVirtual(1000));
 
         [Resolved]
         private BeatmapStorage beatmaps { get; set; }

--- a/Circle.Game/Rulesets/UI/InputManager.cs
+++ b/Circle.Game/Rulesets/UI/InputManager.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using System.Linq;
+using Circle.Game.Beatmaps;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Input.Events;
+using osuTK.Input;
+
+namespace Circle.Game.Rulesets.UI
+{
+    public class InputManager : Container
+    {
+        public override bool PropagatePositionalInputSubTree => false;
+        public override bool PropagateNonPositionalInputSubTree => false;
+
+        public Beatmap Beatmap { get; set; }
+
+        private readonly IReadOnlyList<Key> allowedKeys;
+        private IReadOnlyList<double> tileHitTimes => Beatmap.TileStartTime;
+        public double TimeUntilNextBeat;
+        public double TimeSinceLastBeat;
+        public int Floor = 1;
+
+        public InputManager()
+        {
+            List<Key> keys = new List<Key> { Key.Up, Key.Down, Key.Left, Key.Right, Key.Space };
+
+            for (int i = 67; i <= 130; i++)
+                keys.Add((Key)i);
+
+            allowedKeys = keys;
+        }
+
+        protected override void LoadComplete()
+        {
+            for (int i = 1; i < tileHitTimes.Count - 1; i++)
+            {
+                using (BeginAbsoluteSequence(tileHitTimes[i], false))
+                    this.TransformTo("Floor", i + 1);
+            }
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (Floor < tileHitTimes.Count)
+            {
+                TimeUntilNextBeat = tileHitTimes[Floor] - Time.Current;
+
+                if (Floor - 1 > 0)
+                    TimeSinceLastBeat = Time.Current - tileHitTimes[Floor - 1];
+            }
+        }
+
+        protected override bool OnKeyDown(KeyDownEvent e)
+        {
+            return allowedKeys.All(key => e.Key != key);
+        }
+    }
+}

--- a/Circle.Game/Screens/Play/GameplayMusicController.cs
+++ b/Circle.Game/Screens/Play/GameplayMusicController.cs
@@ -1,0 +1,75 @@
+using System;
+using Circle.Game.Beatmaps;
+using Circle.Game.Overlays;
+using osu.Framework.Audio;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Audio;
+using osu.Framework.Graphics.Transforms;
+using osu.Framework.Threading;
+
+namespace Circle.Game.Screens.Play
+{
+    public class GameplayMusicController : MusicController
+    {
+        public BeatmapInfo BeatmapInfo { get; }
+
+        /// <summary>
+        /// 재생 지연 시간.
+        /// </summary>
+        public double TimeUntilPlay { get; private set; }
+
+        public GameplayMusicController(BeatmapInfo beatmapInfo)
+        {
+            BeatmapInfo = beatmapInfo;
+        }
+
+        protected override void LoadComplete() => ChangeTrack(BeatmapInfo);
+
+        /// <summary>
+        /// 오프셋을 설정합니다.
+        /// 오프셋이 음수이거나 카운트다운이 오프셋보다 긴 경우 음악을 재생할 때 그 차이만큼 지연됩니다.
+        /// </summary>
+        /// <param name="offset">게임플레이 시작 오프셋.</param>
+        /// <param name="countdown">게임이 시작하기 전 카운트다운 지속시간.</param>
+        public void SetOffset(double offset, double countdown)
+        {
+            if (offset - countdown < 0)
+                TimeUntilPlay = Math.Abs(offset - countdown);
+            else
+                TimeUntilPlay = 0;
+
+            SeekTo(Math.Clamp(offset - countdown, 0, double.MaxValue));
+        }
+
+        /// <summary>
+        /// 음악 재생을 시작합니다.
+        /// </summary>
+        public void Start()
+        {
+            VolumeTo(1);
+            Scheduler.AddDelayed(() => Play(), TimeUntilPlay);
+        }
+
+        /// <summary>
+        /// 서서히 음악재생을 중지합니다.
+        /// </summary>
+        public void Pause() => VolumeTo(0, 750, Easing.OutPow10).Then().Schedule(Stop);
+
+        /// <summary>
+        /// 마지막으로 설정된 오프셋을 기준으로 재생을 재개합니다.
+        /// 플레이 보장을 위해 DelayUntilTransformsFinished()를 사용해주세요.
+        /// </summary>
+        public ScheduledDelegate Resume()
+        {
+            return Scheduler.AddDelayed(() =>
+            {
+                VolumeTo(1, TimeUntilPlay == 0 ? TimeUntilPlay : 0, Easing.OutPow10);
+                Play();
+            }, TimeUntilPlay);
+        }
+
+        public TransformSequence<DrawableTrack> DelayUntilTransformsFinished() => CurrentTrack.DelayUntilTransformsFinished();
+
+        public TransformSequence<DrawableTrack> VolumeTo(double newVolume, double duration = 0, Easing easing = Easing.None) => CurrentTrack.VolumeTo(newVolume, duration, easing);
+    }
+}

--- a/Circle.Game/Screens/Play/GameplayMusicController.cs
+++ b/Circle.Game/Screens/Play/GameplayMusicController.cs
@@ -1,4 +1,3 @@
-using System;
 using Circle.Game.Beatmaps;
 using Circle.Game.Overlays;
 using osu.Framework.Audio;
@@ -44,7 +43,8 @@ namespace Circle.Game.Screens.Play
                 SeekTo(offset);
             }
 
-            SeekTo(Math.Clamp(offset - countdown, 0, double.MaxValue));
+            // Todo: Player의 오프셋 설정을 일관되게 정리해야합니다.
+            //SeekTo(Math.Clamp(offset - countdown, 0, double.MaxValue));
         }
 
         /// <summary>

--- a/Circle.Game/Screens/Play/GameplayMusicController.cs
+++ b/Circle.Game/Screens/Play/GameplayMusicController.cs
@@ -33,10 +33,16 @@ namespace Circle.Game.Screens.Play
         /// <param name="countdown">게임이 시작하기 전 카운트다운 지속시간.</param>
         public void SetOffset(double offset, double countdown)
         {
-            if (offset - countdown < 0)
-                TimeUntilPlay = Math.Abs(offset - countdown);
-            else
+            if (offset - countdown >= 0)
+            {
                 TimeUntilPlay = 0;
+                SeekTo(offset - countdown);
+            }
+            else
+            {
+                TimeUntilPlay = countdown;
+                SeekTo(offset);
+            }
 
             SeekTo(Math.Clamp(offset - countdown, 0, double.MaxValue));
         }
@@ -59,13 +65,13 @@ namespace Circle.Game.Screens.Play
         /// 마지막으로 설정된 오프셋을 기준으로 재생을 재개합니다.
         /// 플레이 보장을 위해 DelayUntilTransformsFinished()를 사용해주세요.
         /// </summary>
-        public ScheduledDelegate Resume()
+        public ScheduledDelegate Resume(double timeUntilResume = 0)
         {
             return Scheduler.AddDelayed(() =>
             {
                 VolumeTo(1, TimeUntilPlay == 0 ? TimeUntilPlay : 0, Easing.OutPow10);
                 Play();
-            }, TimeUntilPlay);
+            }, TimeUntilPlay + timeUntilResume);
         }
 
         public TransformSequence<DrawableTrack> DelayUntilTransformsFinished() => CurrentTrack.DelayUntilTransformsFinished();

--- a/Circle.Game/Screens/Play/HUD/HUDOverlay.cs
+++ b/Circle.Game/Screens/Play/HUD/HUDOverlay.cs
@@ -66,7 +66,7 @@ namespace Circle.Game.Screens.Play.HUD
             Countdown(countdownInterval * tick);
         }
 
-        public void Countdown(float startUntilTime)
+        public void Countdown(double startUntilTime)
         {
             var tick = beatmap.Settings.CountdownTicks;
             startUntilTime /= tick;

--- a/Circle.Game/Screens/Play/MasterGameplayClockContainer.cs
+++ b/Circle.Game/Screens/Play/MasterGameplayClockContainer.cs
@@ -37,7 +37,12 @@ namespace Circle.Game.Screens.Play
                 container = new FrameStabilityContainer(beatmap.Settings.VidOffset + gameplayStartTime - countdownDuration),
                 new FrameStabilityContainer(gameplayStartTime)
                 {
-                    Child = Playfield = new Playfield(beatmap, gameplayStartTime, countdownDuration),
+                    Child = new InputManager
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Beatmap = beatmap,
+                        Child = Playfield = new Playfield(beatmap, gameplayStartTime, countdownDuration)
+                    }
                 }
             };
 

--- a/Circle.Game/Screens/Play/PlanetContainer.cs
+++ b/Circle.Game/Screens/Play/PlanetContainer.cs
@@ -178,4 +178,10 @@ namespace Circle.Game.Screens.Play
 
         private RotationDirection getIsClockwise(IReadOnlyList<TileInfo> tilesInfo, int floor) => tilesInfo.GetIsClockwise(floor) ? RotationDirection.Clockwise : RotationDirection.Counterclockwise;
     }
+
+    public enum PlanetState
+    {
+        Fire,
+        Ice
+    }
 }

--- a/Circle.Game/Screens/Play/Player.cs
+++ b/Circle.Game/Screens/Play/Player.cs
@@ -320,10 +320,4 @@ namespace Circle.Game.Screens.Play
             });
         }
     }
-
-    public enum PlanetState
-    {
-        Fire,
-        Ice
-    }
 }


### PR DESCRIPTION
## 변경사항

* 비트맵의 타일 정보를 참조할때마다 계산을 수행하지않도록 합니다.
* `player`에서 `MusicController`의 의존성을 최소한으로 합니다.
* 다음 비트까지 남은시간과 마지막비트에서부터 경과한 시간을 제공하는 입력관리자를 추가합니다.
* 게임의 오프셋을 약간 정리합니다. 아직 해야할 작업이 남아있습니다.